### PR TITLE
Fix waiting for operator pods to become ready

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -33,11 +33,11 @@ helm upgrade --install --wait gpu-operator -n gpu-operator --create-namespace nv
     --set migManager.enabled=false \
     --set migManager.config.default=""
 
-echo "> Waiting for container toolkit daemonset pod(s) to become ready"
-kubectl wait pod -n gpu-operator -l app=nvidia-container-toolkit-daemonset --for condition=Ready=true --timeout=360s
+echo "> Waiting for container toolkit daemonset to become ready"
+kubectl rollout status daemonset nvidia-container-toolkit-daemonset -n gpu-operator
 
-echo "> Waiting for device plugin daemonset pod(s) to become ready"
-kubectl wait pod -n gpu-operator -l app=nvidia-device-plugin-daemonset --for condition=Ready=true --timeout=360s
+echo "> Waiting for device plugin daemonset to become ready"
+kubectl rollout status daemonset nvidia-device-plugin-daemonset -n gpu-operator
 
 echo "> Labeling nodes to use custom device plugin configuration"
 kubectl label node --all nvidia.com/device-plugin.config=update-capacity


### PR DESCRIPTION
The problem with `kubectl wait pod` is that it fails when the pod does not exist yet (pre-1.31). Instead, we will use `kubectl rollout status`, which is much more robust for deployments/ daemonsets. The behavior (e.g. timeout) can be fine-tuned if needed.

See https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_status/