### PR TITLE
Operator-sdk update bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,8 @@ endif
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	cd config/manager && $(KUSTOMIZE) edit set image daemonset=$(IMG_DMST)
+	$(KUSTOMIZE) build config/manifests | sed -e "s|<IMG>|$(IMG)|g" -e "s|<IMG_DMST>|$(IMG_DMST)|g" | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
@@ -313,7 +314,7 @@ bundle-build: ## Build the bundle image.
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+	$(CONTAINER_TOOL) push ${BUNDLE_IMG}
 
 .PHONY: opm
 OPM = $(LOCALBIN)/opm

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/manager && $(KUSTOMIZE) edit set image daemonset=$(IMG_DMST)
-	$(KUSTOMIZE) build config/manifests | sed -e "s|<IMG>|$(IMG)|g" -e "s|<IMG_DMST>|$(IMG_DMST)|g" | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/bundle/manifests/inference.codeflare.dev_instaslices.yaml
+++ b/bundle/manifests/inference.codeflare.dev_instaslices.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: instaslice-operator-system/instaslice-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: instaslices.inference.codeflare.dev
 spec:
@@ -21,14 +21,19 @@ spec:
         description: Instaslice is the Schema for the instaslices API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/bundle/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -21,9 +21,14 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-08-28T16:19:03Z"
+    categories: Drivers and plugins
+    containerImage: quay.io/amalvank/instaslicev2-controller:latest
+    createdAt: "2024-09-03T18:44:37Z"
+    description: InstaSlice works with GPU operator to create mig slices on demand
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/openshift/instaslice-operator
+    support: https://github.com/openshift/instaslice-operator/issues
   name: instaslice-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -33,7 +38,30 @@ spec:
     - kind: Instaslice
       name: instaslices.inference.codeflare.dev
       version: v1alpha1
-  description: InstaSlice works with GPU operator to create mig slices on demand.
+  description: |-
+    ### Introduction
+    InstaSlice works with GPU operator to create mig slices on demand.
+
+    ### API Backward Compatibility
+    **NOTE:**  Until Operator supports **seamless upgrades**, a new version of
+    the operator may introduce a change that is **NOT** backwards compatible with
+    the previous version. Thus, to upgrade the operator, uninstall the already
+    installed version completely (including CRDs) and install the new version.
+    For example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by
+    following [uninstall operator section](https://github.com/openshift/instaslice-operator)
+    and install the new version.
+
+    Changes to patch version (major.minor.patch) indicates that no breaking changes
+    are introduced, thus upgrade can be done without uninstalling and reinstalling
+    the operator.
+
+    ### Documentation
+    Documentation and installation guide can be found below:
+      * [Installation Guide](https://github.com/openshift/instaslice-operator)
+      * [Kepler Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)
+
+    ### License
+    instaslice-operator is licensed under the Apache 2.0 license
   displayName: Instaslice
   icon:
   - base64data: ""
@@ -182,7 +210,7 @@ spec:
                     cpu: 10m
                     memory: 64Mi
                 securityContext:
-                  allowPrivilegeEscalation: false
+                  allowPrivilegeEscalation: true
                   capabilities:
                     drop:
                     - ALL
@@ -214,13 +242,44 @@ spec:
                     drop:
                     - ALL
               securityContext:
-                runAsNonRoot: true
+                runAsNonRoot: false
               serviceAccountName: instaslice-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - name: cert
                 secret:
                   secretName: webhook-server-cert
+      daemonsets:          # Add the daemonset section
+      - name: instaslice-operator-daemonset
+      spec:
+        selector:
+          matchLabels:
+            app: controller-daemonset
+        template:
+          metadata:
+            labels:
+              app: controller-daemonset
+          spec:
+            containers:
+            - name: daemonset
+              image: quay.io/amalvank/instaslicev2-daemonset:latest
+              ports:
+              - containerPort: 8443
+                name: https
+                protocol: TCP
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+                requests:
+                  cpu: 5m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: true
+                privileged: true
+                capabilities:
+                  add:
+                  - "ALL"            
       permissions:
       - rules:
         - apiGroups:
@@ -270,22 +329,24 @@ spec:
   - MIG
   links:
   - name: Instaslice Operator
-    url: https://instaslice-operator.domain
+    url: https://github.com/openshift/instaslice-operator
   maintainers:
   - email: amalvank@redhat.com
     name: Abhishek Malvankar
   - email: mmunirab@redhat.com
     name: Mohammed Abdi
   maturity: alpha
+  minKubeVersion: 1.16.0
   provider:
     name: Codeflare
+    url: https://github.com/openshift/instaslice-operator
   version: 0.0.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
     containerPort: 443
     deploymentName: instaslice-operator-controller-manager
-    failurePolicy: Fail
+    failurePolicy: Ignore
     generateName: instaslice.codeflare.dev
     rules:
     - apiGroups:

--- a/config/crd/bases/inference.codeflare.dev_instaslices.yaml
+++ b/config/crd/bases/inference.codeflare.dev_instaslices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: instaslices.inference.codeflare.dev
 spec:
   group: inference.codeflare.dev
@@ -20,14 +20,19 @@ spec:
         description: Instaslice is the Schema for the instaslices API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: $IMG
+        image: controller:latest
         imagePullPolicy: Always
         name: manager
         securityContext:
@@ -128,7 +128,7 @@ spec:
         args:
         - --leader-elect
         name: daemonset
-        image: $IMG_DMST
+        image: daemonset:latest
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: $IMG
         imagePullPolicy: Always
         name: manager
         securityContext:
@@ -128,7 +128,7 @@ spec:
         args:
         - --leader-elect
         name: daemonset
-        image: daemonset:latest
+        image: $IMG_DMST
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         securityContext:

--- a/config/manifests/bases/instaslice-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/instaslice-operator.clusterserviceversion.yaml
@@ -4,6 +4,11 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: Drivers and plugins
+    containerImage: <IMG>
+    description: InstaSlice works with GPU operator to create mig slices on demand
+    repository: https://github.com/openshift/instaslice-operator
+    support: https://github.com/openshift/instaslice-operator/issues
   name: instaslice-operator.v0.0.0
   namespace: placeholder
 spec:
@@ -15,7 +20,30 @@ spec:
       kind: Instaslice
       name: instaslice.inference.codeflare.dev
       version: v1alpha1
-  description: InstaSlice works with GPU operator to create mig slices on demand.
+  description: |-
+    ### Introduction
+    InstaSlice works with GPU operator to create mig slices on demand.
+
+    ### API Backward Compatibility
+    **NOTE:**  Until Operator supports **seamless upgrades**, a new version of
+    the operator may introduce a change that is **NOT** backwards compatible with
+    the previous version. Thus, to upgrade the operator, uninstall the already
+    installed version completely (including CRDs) and install the new version.
+    For example to upgrade from 0.1.0 to 0.2.0, you must uninstall `0.1.0` by
+    following [uninstall operator section](https://github.com/openshift/instaslice-operator)
+    and install the new version.
+
+    Changes to patch version (major.minor.patch) indicates that no breaking changes
+    are introduced, thus upgrade can be done without uninstalling and reinstalling
+    the operator.
+
+    ### Documentation
+    Documentation and installation guide can be found below:
+      * [Installation Guide](https://github.com/openshift/instaslice-operator)
+      * [Kepler Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)
+
+    ### License
+    instaslice-operator is licensed under the Apache 2.0 license
   displayName: Instaslice
   icon:
   - base64data: ""
@@ -38,13 +66,15 @@ spec:
   - MIG
   links:
   - name: Instaslice Operator
-    url: https://instaslice-operator.domain
+    url: https://github.com/openshift/instaslice-operator
   maintainers:
   - email: amalvank@redhat.com
     name: Abhishek Malvankar
   - email: mmunirab@redhat.com
     name: Mohammed Abdi
   maturity: alpha
+  minKubeVersion: 1.16.0
   provider:
     name: Codeflare
+    url: https://github.com/openshift/instaslice-operator
   version: 0.0.0

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,7 +11,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-v1-pod
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: instaslice.codeflare.dev
   rules:
   - apiGroups:


### PR DESCRIPTION
- Deploy operator using bundle
Note: The controller successfully deploys using the bundle, deployment of daemonset using the bundle needs more work (to follow in consecutive pr), and documentation of deployment using SDK bundle will follow in a separate pr as well. 
- Update readme with nits