### PR TITLE
Update cert manager, Kind node image, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,7 @@ for documentation on building mutli-platform images with Docker. You can change 
 # PLATFORMS=linux/arm64,linux/amd64 make docker-buildx
 ```
 
-2. Deploy the cert manager
-
-```console
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
-```
-
-3. Deploy the controller and daemonset with the default images. All required CRDs will be installed by this command:
+2. Deploy the controller and daemonset with the default images. All required CRDs will be installed by this command:
 
 ```console
 # make deploy
@@ -187,13 +181,13 @@ Or with custom images:
 # IMG=<registry>/<controller-image>:<tag> IMG_DMST=<registry>/<daemonset-image>:<tag> make docker-build docker-push deploy
 ```
 
-4. Verify that the InstaSlice pods are successfully running:
+3. Verify that the InstaSlice pods are successfully running:
 
 ```console
-# kubectl get pod -n instaslicev2-system
+# kubectl get pod -n instaslice-operator-system
 NAME                                               READY   STATUS    RESTARTS   AGE
-instaslicev2-controller-daemonset-5lbqg            1/1     Running   0          101s
-instaslicev2-controller-manager-57b549784c-wkqq2   2/2     Running   0          101s
+instaslice-operator-controller-daemonset-7vm6n            1/1     Running   0          39s
+instaslice-operator-controller-manager-55d7c495d4-g27gl   2/2     Running   0          39s
 ```
 
 **Note**: If you encounter RBAC errors, you may need to grant yourself cluster-admin privileges or be logged in as admin.

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -11,7 +11,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
 - role: control-plane
-  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+  image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
   # required for GPU workaround
   extraMounts:
     - hostPath: /dev/null
@@ -23,6 +23,9 @@ docker exec -ti kind-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real
 
 echo "> Unmounting the nvidia devices in the control-plane container"
 docker exec -ti kind-control-plane umount -R /proc/driver/nvidia
+
+echo "> Deploying cert manager"
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml
 
 # According to https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html
 echo "> Adding/updateding the NVIDIA Helm repository"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,7 +53,7 @@ var _ = Describe("controller", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create namespace: %s", outputNs))
 
 		By("installing cert manager")
-		cmdCm := exec.Command("kubectl", "apply", "-f", "https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml")
+		cmdCm := exec.Command("kubectl", "apply", "-f", "https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml")
 		outputCm, err := cmdCm.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to deploy cert manager: %s", outputCm))
 


### PR DESCRIPTION
* Fix operator namespace in README
* Deploy cert manager in the setup script instead of manually
* Bump cert manager version from 1.14.3 to 1.15.3
* Bump Kind node image from 1.27 to 1.30