### PR TITLE
Kueue integration

### DIFF
--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -85,7 +85,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Pods with scheduling gates other than the InstaSlice gate are not ready to be scheduled and should be ignored
-	if IsPodGatedByOthers(pod) {
+	if isPodGatedByOthers(pod) {
 		//log.FromContext(ctx).Info("Ignoring gated pod", "pod", pod.Name)
 		return ctrl.Result{}, nil
 	}
@@ -371,8 +371,8 @@ func checkIfPodGated(pod *v1.Pod, isPodGated bool) bool {
 	return isPodGated
 }
 
-// IsPodGatedByOthers looks for scheduling gates distinct from the InstaSlice gate
-func IsPodGatedByOthers(pod *v1.Pod) bool {
+// isPodGatedByOthers looks for scheduling gates distinct from the InstaSlice gate
+func isPodGatedByOthers(pod *v1.Pod) bool {
 	for _, gate := range pod.Spec.SchedulingGates {
 		if gate.Name != "org.instaslice/accelarator" {
 			return true

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -84,6 +84,12 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
+	// Pods with scheduling gates other than the InstaSlice gate are not ready to be scheduled and should be ignored
+	if IsPodGatedByOthers(pod) {
+		//log.FromContext(ctx).Info("Ignoring gated pod", "pod", pod.Name)
+		return ctrl.Result{}, nil
+	}
+
 	isPodGated = checkIfPodGated(pod, isPodGated)
 
 	if !isPodGated && !controllerutil.ContainsFinalizer(pod, "org.instaslice/accelarator") {
@@ -363,6 +369,16 @@ func checkIfPodGated(pod *v1.Pod, isPodGated bool) bool {
 		}
 	}
 	return isPodGated
+}
+
+// IsPodGatedByOthers looks for scheduling gates distinct from the InstaSlice gate
+func IsPodGatedByOthers(pod *v1.Pod) bool {
+	for _, gate := range pod.Spec.SchedulingGates {
+		if gate.Name != "org.instaslice/accelarator" {
+			return true
+		}
+	}
+	return false
 }
 
 // podMapFunc maps pods to instaslice created allocations


### PR DESCRIPTION
Fixes #82.

This PR ensures InstaSlice does not process pods with scheduling gates other than its own. In particular, this PR delays the allocation and preparation of slices for pods queued by Kueue until admission.