### PR TITLE
add emulator e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
+# Utilize Kind and run a simple e2e with emulator mode
+.PHONY: test-e2e-emulator
+test-e2e-emulator:
+	go test ./test/e2e_emulator/ -v -ginkgo.v
+
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.54.2
 golangci-lint:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -76,21 +76,21 @@ var _ = Describe("controller", Ordered, func() {
 
 			By("building the manager(Operator) image")
 			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = utils.Run(cmd)
+			_, err = utils.Run(cmd, "test/e2e")
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("loading the manager(Operator) image on Kind")
-			err = utils.LoadImageToKindClusterWithName(projectimage)
+			err = utils.LoadImageToKindClusterWithName(projectimage, "test/e2e")
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("installing CRDs")
 			cmd = exec.Command("make", "install")
-			_, err = utils.Run(cmd)
+			_, err = utils.Run(cmd, "test/e2e")
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("deploying the controller-manager")
 			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
-			_, err = utils.Run(cmd)
+			_, err = utils.Run(cmd, "test/e2e")
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("validating that the controller-manager pod is running as expected")

--- a/test/e2e_emulator/e2e_suite_test.go
+++ b/test/e2e_emulator/e2e_suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_emulator
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Run e2e tests using the Ginkgo runner.
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting instaslice-operator suite for emulator\n")
+	RunSpecs(t, "e2e suite")
+}

--- a/test/e2e_emulator/resources/emulator-pod.yaml
+++ b/test/e2e_emulator/resources/emulator-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cuda-vectoradd-1
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: cuda-vectoradd-1
+    image: "quay.io/tardieu/vectoradd:0.1.0"
+    resources:
+      limits:
+        nvidia.com/mig-1g.5gb: 1
+    command:
+      - sh
+      - -c
+      -  "sleep 180"
+      # requests:
+      #   cpu: 1000m
+      #   memory: 512Mi

--- a/test/e2e_emulator/resources/instaslice-fake-capacity.yaml
+++ b/test/e2e_emulator/resources/instaslice-fake-capacity.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+items:
+- apiVersion: inference.codeflare.dev/v1alpha1
+  kind: Instaslice
+  metadata:
+    name: kind-control-plane
+    namespace: default
+  spec:
+    cpuonnodeatboot: 72
+    memoryonnodeatboot: 1000000000
+    MigGPUUUID:
+      GPU-8d042338-e67f-9c48-92b4-5b55c7e5133c: NVIDIA A100-PCIE-40GB
+      GPU-31cfe05c-ed13-cd17-d7aa-c63db5108c24: NVIDIA A100-PCIE-40GB
+    migplacement:
+    - ciProfileid: 0
+      ciengprofileid: 0
+      giprofileid: 0
+      placements:
+      - size: 1
+        start: 0
+      - size: 1
+        start: 1
+      - size: 1
+        start: 2
+      - size: 1
+        start: 3
+      - size: 1
+        start: 4
+      - size: 1
+        start: 5
+      - size: 1
+        start: 6
+      profile: 1g.5gb
+    - ciProfileid: 1
+      ciengprofileid: 0
+      giprofileid: 1
+      placements:
+      - size: 2
+        start: 0
+      - size: 2
+        start: 2
+      - size: 2
+        start: 4
+      profile: 2g.10gb
+    - ciProfileid: 2
+      ciengprofileid: 0
+      giprofileid: 2
+      placements:
+      - size: 4
+        start: 0
+      - size: 4
+        start: 4
+      profile: 3g.20gb
+    - ciProfileid: 3
+      ciengprofileid: 0
+      giprofileid: 3
+      placements:
+      - size: 4
+        start: 0
+      profile: 4g.20gb
+    - ciProfileid: 4
+      ciengprofileid: 0
+      giprofileid: 4
+      placements:
+      - size: 8
+        start: 0
+      profile: 7g.40gb
+    - ciProfileid: 7
+      ciengprofileid: 0
+      giprofileid: 7
+      placements:
+      - size: 1
+        start: 0
+      - size: 1
+        start: 1
+      - size: 1
+        start: 2
+      - size: 1
+        start: 3
+      - size: 1
+        start: 4
+      - size: 1
+        start: 5
+      - size: 1
+        start: 6
+      profile: 1g.5gb+me
+    - ciProfileid: 9
+      ciengprofileid: 0
+      giprofileid: 9
+      placements:
+      - size: 2
+        start: 0
+      - size: 2
+        start: 2
+      - size: 2
+        start: 4
+      - size: 2
+        start: 6
+      profile: 1g.10gb
+    prepared:
+      MIG-0f1cecc2-27a4-5452-85f2-ad9c3a15f1de:
+        ciinfo: 0
+        giinfo: 2
+        parent: GPU-31cfe05c-ed13-cd17-d7aa-c63db5108c24
+        podUUID: ""
+        profile: 3g.20gb
+        size: 4
+        start: 4
+      MIG-3dc2c68a-45e6-5acb-b043-caef296e6038:
+        ciinfo: 0
+        giinfo: 2
+        parent: GPU-8d042338-e67f-9c48-92b4-5b55c7e5133c
+        podUUID: ""
+        profile: 3g.20gb
+        size: 4
+        start: 4
+  status:
+    processed: "true"
+kind: List


### PR DESCRIPTION
Add a e2e test that uses the emulator and does not rely on any GPU.

I wanted a quick way to run the emulator pod and I realize that we probably want to use this for CI eventually.