### PR TITLE
fix finalizer and extend res

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -17,9 +17,10 @@ limitations under the License.
 package controller
 
 const (
-	finalizerOrGateName      string = "org.instaslice/accelerator"
-	emulatorModeFalse        string = "false"
-	emulatorModeTrue         string = "true"
-	orgInstaslicePrefix      string = "org.instaslice/"
-	AttributeMediaExtensions string = "me"
+	finalizerOrGateName         string = "org.instaslice/accelerator"
+	emulatorModeFalse           string = "false"
+	emulatorModeTrue            string = "true"
+	orgInstaslicePrefix         string = "org.instaslice/"
+	AttributeMediaExtensions    string = "me"
+	instaSliceOperatorNamespace string = "default"
 )

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,129 +33,132 @@ import (
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
 )
 
-var _ = Describe("InstasliceReconciler processInstasliceAllocation", func() {
-	var (
-		ctx                 context.Context
-		r                   *InstasliceReconciler
-		fakeClient          client.Client
-		instaslice          *inferencev1alpha1.Instaslice
-		pod                 *v1.Pod
-		podUUID             string
-		req                 ctrl.Request
-		instasliceNamespace string
-	)
+func TestChangesAllocationDeletionndFinalizer(t *testing.T) {
+	var _ = Describe("InstasliceReconciler processInstasliceAllocation", func() {
+		var (
+			ctx                 context.Context
+			r                   *InstasliceReconciler
+			fakeClient          client.Client
+			instaslice          *inferencev1alpha1.Instaslice
+			pod                 *v1.Pod
+			podUUID             string
+			req                 ctrl.Request
+			instasliceNamespace string
+		)
 
-	BeforeEach(func() {
-		ctx = context.TODO()
+		BeforeEach(func() {
+			ctx = context.TODO()
 
-		scheme := runtime.NewScheme()
-		Expect(inferencev1alpha1.AddToScheme(scheme)).To(Succeed())
-		Expect(v1.AddToScheme(scheme)).To(Succeed())
+			scheme := runtime.NewScheme()
+			Expect(inferencev1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(v1.AddToScheme(scheme)).To(Succeed())
 
-		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+			fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		r = &InstasliceReconciler{
-			Client: fakeClient,
-		}
+			r = &InstasliceReconciler{
+				Client: fakeClient,
+			}
 
-		instasliceNamespace = "default"
-		podUUID = "test-pod-uuid"
+			instasliceNamespace = "default"
+			podUUID = "test-pod-uuid"
 
-		instaslice = &inferencev1alpha1.Instaslice{
-			Spec: inferencev1alpha1.InstasliceSpec{
-				Allocations: map[string]inferencev1alpha1.AllocationDetails{
-					podUUID: {
-						PodUUID:          podUUID,
-						PodName:          "test-pod",
-						Allocationstatus: inferencev1alpha1.AllocationStatusCreating,
+			instaslice = &inferencev1alpha1.Instaslice{
+				Spec: inferencev1alpha1.InstasliceSpec{
+					Allocations: map[string]inferencev1alpha1.AllocationDetails{
+						podUUID: {
+							PodUUID:          podUUID,
+							PodName:          "test-pod",
+							Allocationstatus: inferencev1alpha1.AllocationStatusCreating,
+						},
 					},
 				},
-			},
-		}
-		instaslice.Name = "test-instaslice"
-		instaslice.Namespace = instasliceNamespace
-		pod = &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: instasliceNamespace,
-				UID:       types.UID(podUUID),
-				Finalizers: []string{
-					finalizerOrGateName,
+			}
+			instaslice.Name = "test-instaslice"
+			instaslice.Namespace = instasliceNamespace
+			pod = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: instasliceNamespace,
+					UID:       types.UID(podUUID),
+					Finalizers: []string{
+						finalizerOrGateName,
+					},
 				},
-			},
-		}
+			}
 
-		Expect(fakeClient.Create(ctx, instaslice)).To(Succeed())
-		Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, instaslice)).To(Succeed())
+			Expect(fakeClient.Create(ctx, pod)).To(Succeed())
 
-		req = ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "test-pod",
-				Namespace: instasliceNamespace,
-			},
-		}
+			req = ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-pod",
+					Namespace: instasliceNamespace,
+				},
+			}
+		})
+
+		It("should delete instaslice allocation when allocation status is Deleted", func() {
+			instaslice.Spec.Allocations[podUUID] = inferencev1alpha1.AllocationDetails{
+				PodUUID:          podUUID,
+				PodName:          "test-pod",
+				Allocationstatus: inferencev1alpha1.AllocationStatusDeleted,
+			}
+			Expect(fakeClient.Update(ctx, instaslice)).To(Succeed())
+
+			found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			updatedInstaSlice := &inferencev1alpha1.Instaslice{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: instasliceNamespace}, updatedInstaSlice)).To(Succeed())
+			_, allocationExists := updatedInstaSlice.Spec.Allocations[podUUID]
+			Expect(allocationExists).To(BeFalse())
+		})
+
+		It("should remove finalizer after allocation is deleted", func() {
+			instaslice.Spec.Allocations[podUUID] = inferencev1alpha1.AllocationDetails{
+				PodUUID:          podUUID,
+				PodName:          "test-pod",
+				Allocationstatus: inferencev1alpha1.AllocationStatusDeleted,
+			}
+			Expect(fakeClient.Update(ctx, instaslice)).To(Succeed())
+
+			found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			updatedPod := &v1.Pod{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedPod)).To(Succeed())
+			Expect(updatedPod.Finalizers).NotTo(ContainElement(finalizerOrGateName))
+		})
+
+		It("should set allocation status to Deleting if status is not Deleted", func() {
+			found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			updatedInstaSlice := &inferencev1alpha1.Instaslice{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: instasliceNamespace}, updatedInstaSlice)).To(Succeed())
+
+			Expect(updatedInstaSlice.Spec.Allocations[podUUID].Allocationstatus).To(Equal(inferencev1alpha1.AllocationStatusDeleting))
+
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+
+		It("should requeue if there is an error updating the instaslice", func() {
+			r.Client = fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+
+			found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
+
+			Expect(found).To(BeTrue())
+			Expect(err).To(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+		})
 	})
 
-	It("should delete instaslice allocation when allocation status is Deleted", func() {
-		instaslice.Spec.Allocations[podUUID] = inferencev1alpha1.AllocationDetails{
-			PodUUID:          podUUID,
-			PodName:          "test-pod",
-			Allocationstatus: inferencev1alpha1.AllocationStatusDeleted,
-		}
-		Expect(fakeClient.Update(ctx, instaslice)).To(Succeed())
-
-		found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(found).To(BeTrue())
-		Expect(result).To(Equal(ctrl.Result{}))
-
-		updatedInstaSlice := &inferencev1alpha1.Instaslice{}
-		Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: instasliceNamespace}, updatedInstaSlice)).To(Succeed())
-		_, allocationExists := updatedInstaSlice.Spec.Allocations[podUUID]
-		Expect(allocationExists).To(BeFalse())
-	})
-
-	It("should remove finalizer after allocation is deleted", func() {
-		instaslice.Spec.Allocations[podUUID] = inferencev1alpha1.AllocationDetails{
-			PodUUID:          podUUID,
-			PodName:          "test-pod",
-			Allocationstatus: inferencev1alpha1.AllocationStatusDeleted,
-		}
-		Expect(fakeClient.Update(ctx, instaslice)).To(Succeed())
-
-		found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(found).To(BeTrue())
-		Expect(result).To(Equal(ctrl.Result{}))
-
-		updatedPod := &v1.Pod{}
-		Expect(fakeClient.Get(ctx, req.NamespacedName, updatedPod)).To(Succeed())
-		Expect(updatedPod.Finalizers).NotTo(ContainElement(finalizerOrGateName))
-	})
-
-	It("should set allocation status to Deleting if status is not Deleted", func() {
-		found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(found).To(BeTrue())
-
-		updatedInstaSlice := &inferencev1alpha1.Instaslice{}
-		Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: instasliceNamespace}, updatedInstaSlice)).To(Succeed())
-
-		Expect(updatedInstaSlice.Spec.Allocations[podUUID].Allocationstatus).To(Equal(inferencev1alpha1.AllocationStatusDeleting))
-
-		Expect(result).To(Equal(ctrl.Result{}))
-	})
-
-	It("should requeue if there is an error updating the instaslice", func() {
-		r.Client = fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
-
-		found, result, err := r.processInstasliceAllocation(ctx, instaslice.Name, podUUID, instaslice.Spec.Allocations[podUUID], req)
-
-		Expect(found).To(BeTrue())
-		Expect(err).To(HaveOccurred())
-		Expect(result.Requeue).To(BeTrue())
-	})
-})
+}

--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -376,28 +376,6 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 
 		}
 
-		// delete slice
-		if allocations.Allocationstatus == inferencev1alpha1.AllocationStatusDeleted && allocations.Nodename == nodeName {
-			var updateInstasliceObject inferencev1alpha1.Instaslice
-			typeNamespacedName := types.NamespacedName{
-				Name:      instaslice.Name,
-				Namespace: "default", // TODO: modify
-			}
-			err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
-			if err != nil {
-				log.FromContext(ctx).Error(err, "error getting latest instaslice object")
-				return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
-			}
-			delete(updateInstasliceObject.Spec.Allocations, allocations.PodUUID)
-			errUpdatingAllocation := r.Update(ctx, &updateInstasliceObject)
-			if errUpdatingAllocation != nil {
-				log.FromContext(ctx).Error(errUpdatingAllocation, "Error updating InstaSlice object for ", "pod", allocations.PodName)
-				// deleted allocations are re-used by the controller, we can be slow to delete these
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			}
-
-		}
-
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -653,7 +652,6 @@ func (r *InstaSliceDaemonsetReconciler) updateNodeCapacity(ctx context.Context, 
 		log.FromContext(ctx).Error(err, "unable to get node object")
 		return err
 	}
-	originalNode := node.DeepCopy()
 	// In a real cluster this will never be nil
 	// it was added to pass the unit test.
 	if node.Status.Capacity == nil {
@@ -670,13 +668,7 @@ func (r *InstaSliceDaemonsetReconciler) updateNodeCapacity(ctx context.Context, 
 			node.Labels["nvidia.com/device-plugin.config"] = "update-capacity-1"
 		}
 	}
-
 	if emulatorMode == emulatorModeTrue {
-		originalData, err := json.Marshal(originalNode)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to marshal original node")
-			return err
-		}
 		if allocation.Allocationstatus == inferencev1alpha1.AllocationStatusCreating {
 			// assume only one quantity can be requested for a profile
 			resourceName := "nvidia.com/mig-" + allocation.Profile
@@ -715,44 +707,20 @@ func (r *InstaSliceDaemonsetReconciler) updateNodeCapacity(ctx context.Context, 
 				}
 			}
 			log.FromContext(ctx).Info("capacity while deleting", "count", countCapacity)
-			resourceQuantity := resource.NewQuantity(1, resource.DecimalSI)
 			extendedResCapacityQuantity := resource.NewQuantity(int64(countCapacity), resource.DecimalSI)
-			existingCapacity, capacityExists := node.Status.Capacity[v1.ResourceName(resourceName)]
+			_, capacityExists := node.Status.Capacity[v1.ResourceName(resourceName)]
 
 			if capacityExists {
-				log.FromContext(ctx).Info("subtraction resource ", "name", resourceName, "pod", allocation.PodName)
-				if extendedResCapacityQuantity.Value() == 0 {
-					zeroQuantity := resource.NewQuantity(0, resource.DecimalSI)
-					existingCapacity.Set(zeroQuantity.Value())
-					if existingCapacity.Sign() != -1 {
-						log.FromContext(ctx).Info("simulator reduced capacity is ", "num", existingCapacity)
-						node.Status.Capacity[v1.ResourceName(resourceName)] = existingCapacity
-					}
-				}
-
-				if existingCapacity.Cmp(*extendedResCapacityQuantity) == 1 || existingCapacity.Cmp(*extendedResCapacityQuantity) == 0 {
-					existingCapacity.Sub(*resourceQuantity)
-					if existingCapacity.Sign() != -1 {
-						log.FromContext(ctx).Info("simulator reduced capacity is ", "num", existingCapacity)
-						node.Status.Capacity[v1.ResourceName(resourceName)] = existingCapacity
-					}
-				}
+				log.FromContext(ctx).Info("asmalvan: subtraction resource ", "name", resourceName, "pod", allocation.PodName)
+				// deletes have multiple scenarios, it can decrease the capacity, stay the same due to new instaslice resource added
+				// or drop to zero for last pod, hence we just try to be in sync with count of org.instaslice resource
+				node.Status.Capacity[v1.ResourceName(resourceName)] = *extendedResCapacityQuantity
 			}
 
 			log.FromContext(ctx).Info("done updating the capacity for ", "allocation", allocation.Allocationstatus)
 		}
 
-		modifiedData, err := json.Marshal(node)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to marshal modified node")
-			return err
-		}
-		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(originalData, modifiedData, v1.Node{})
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to create patch")
-			return err
-		}
-		err = r.Status().Patch(ctx, node, client.RawPatch(types.StrategicMergePatchType, patchBytes))
+		err = r.Status().Update(ctx, node)
 		if err != nil {
 			log.FromContext(ctx).Error(err, "failed to patch node status")
 			return err

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -688,7 +688,7 @@ var _ = Describe("controller", Ordered, func() {
 
 				_, found := instaslice["allocations"].([]interface{})
 				if found {
-					return fmt.Errorf("allocations fieldc found in Instaslice object")
+					return fmt.Errorf("allocations field found in Instaslice object")
 				}
 
 				return nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,7 +46,7 @@ var _ = Describe("controller", Ordered, func() {
 
 	BeforeAll(func() {
 		fmt.Println("Setting up Kind cluster")
-		cmd := exec.Command("kind", "create", "cluster")
+		cmd := exec.Command("kind", "create", "cluster", "--image", "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e")
 		output, err := cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create Kind cluster: %s", output))
 
@@ -102,6 +102,11 @@ var _ = Describe("controller", Ordered, func() {
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
+			By("installing fake GPU capacity")
+			cmdCm := exec.Command("kubectl", "apply", "-f", "test/e2e/resources/instaslice-fake-capacity.yaml")
+			outputCm, err := cmdCm.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to add fake capacity to the cluster: %s", outputCm))
+
 			By("deploying the controller-manager & controller-daemonset")
 			cmd = exec.Command(
 				"make",
@@ -128,17 +133,6 @@ var _ = Describe("controller", Ordered, func() {
 
 			time.Sleep(time.Minute)
 
-			By("installing fake GPU capacity")
-			cmdCm := exec.Command("kubectl", "apply", "-f", "test/e2e/resources/instaslice-fake-capacity.yaml")
-			outputCm, err := cmdCm.CombinedOutput()
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to add fake capacity to the cluster: %s", outputCm))
-
-			By("installing accelerator resource in the cluster")
-			patch := `[{"op":"add","path":"/status/capacity/nvidia.com~1accelerator-memory","value":"80Gi"}]`
-			nodeName := "kind-control-plane"
-			cmdPatch := exec.Command("kubectl", "patch", "node", nodeName, "--subresource=status", "--type=json", "-p", patch)
-			outputPatchRes, err := cmdPatch.CombinedOutput()
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to add fake capacity to the cluster: %s", outputPatchRes))
 		})
 
 		It("should apply the YAML and check if that instaslice resource exists", func() {
@@ -666,6 +660,39 @@ var _ = Describe("controller", Ordered, func() {
 			// Step 3: Verify the node's accelerator memory matches the total GPU memory in Instaslice
 			By("Verifying that node's accelerator memory matches Instaslice total GPU memory")
 			Expect(nodeMemoryGB).To(BeNumerically("==", totalMemoryGB), "nvidia.com/accelerator-memory on node does not match total GPU memory in Instaslice object")
+		})
+		// NOTE: Keep this as the last test in e2e test suite, when all workloads are deleted
+		// there should be no allocations in InstaSlice object.
+		It("should verify that there are no allocations on the Instaslice object", func() {
+			Eventually(func() error {
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "default", "-o", "json")
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					return fmt.Errorf("failed to get Instaslice object: %s", string(output))
+				}
+
+				var instasliceResult struct {
+					Items []map[string]interface{} `json:"items"`
+				}
+
+				err = json.Unmarshal(output, &instasliceResult)
+				if err != nil {
+					return fmt.Errorf("failed to parse Instaslice JSON output: %s", err)
+				}
+
+				if len(instasliceResult.Items) == 0 {
+					return fmt.Errorf("no Instaslice objects found")
+				}
+
+				instaslice := instasliceResult.Items[0]
+
+				_, found := instaslice["allocations"].([]interface{})
+				if found {
+					return fmt.Errorf("allocations fieldc found in Instaslice object")
+				}
+
+				return nil
+			}, "60s", "5s").Should(Succeed(), "Expected no allocations in the Instaslice object")
 		})
 
 	})


### PR DESCRIPTION
This PR solved non-determinism issues with the system :
- For removing InstaSlice finalizer on the pods
- Updating the count in extended resources mode
and Pinning e2e test cases to use the same version as `deploy.sh` script.