### PR TITLE
Enable emulated mode in Openshift 4.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,21 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG} daemonset=${IMG_DMST}
 	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | $(KUBECTL) apply -f -
 
+.PHONY: ocp-deploy
+ocp-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG} daemonset=${IMG_DMST}
+	$(KUBECTL) apply -f config/rbac/instaslice-operator-scc.yaml
+	$(KUBECTL) apply -f config/rbac/openshift_scc_cluster_role_binding.yaml
+	$(KUBECTL) apply -f config/rbac/openshift_role_binding.yaml
+	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | $(KUBECTL) apply -f -
+
 .PHONY: deploy-emulated ## Deploy controller in emulator mode
 deploy-emulated: KUSTOMIZATION=emulator
 deploy-emulated: deploy
+
+.PHONY: ocp-deploy-emulated ## Deploy controller in emulator mode in Openshift
+ocp-deploy-emulated: KUSTOMIZATION=emulator
+ocp-deploy-emulated: ocp-deploy
 
 # .PHONY: deploy-daemonset
 # deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
@@ -242,9 +254,20 @@ deploy-emulated: deploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: ocp-undeploy
+ocp-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUBECTL) delete -f config/rbac/instaslice-operator-scc.yaml
+	$(KUBECTL) delete -f config/rbac/openshift_scc_cluster_role_binding.yaml
+	$(KUBECTL) apply -f config/rbac/openshift_role_binding.yaml
+
 .PHONY: undeploy-emulated
 undeploy-emulated: KUSTOMIZATION=emulator ## Undeploy controller deployed in emulator mode
 undeploy-emulated: undeploy
+
+.PHONY: ocp-undeploy-emulated
+ocp-undeploy-emulated: KUSTOMIZATION=emulator ## Undeploy controller deployed in emulator mode in Openshift
+ocp-undeploy-emulated: ocp-undeploy
 
 ##@ Build Dependencies
 

--- a/config/rbac/instaslice-operator-scc.yaml
+++ b/config/rbac/instaslice-operator-scc.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: instaslice-operator-scc
+allowPrivilegedContainer: true
+allowedCapabilities:
+- "ALL"
+allowPrivilegeEscalation: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+readOnlyRootFilesystem: false

--- a/config/rbac/openshift_cluster_role.yaml
+++ b/config/rbac/openshift_cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:scc:instaslice-operator-scc
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - instaslice-operator-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/config/rbac/openshift_scc_cluster_role_binding.yaml
+++ b/config/rbac/openshift_scc_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: use-scc-instaslice-operator
+subjects:
+- kind: ServiceAccount
+  name: instaslice-operator-controller-manager
+  namespace: instaslice-operator-system
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:instaslice-operator-scc
+  apiGroup: rbac.authorization.k8s.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,7 +11,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-v1-pod
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: instaslice.codeflare.dev
   rules:
   - apiGroups:

--- a/docs/instaslice-emulator-openshift-4.18.md
+++ b/docs/instaslice-emulator-openshift-4.18.md
@@ -1,0 +1,141 @@
+# Emulator Mode in InstaSlice for OpenShift 4.18
+
+Finding MIGable GPUs with cloud providers is expensive and challenging, especially for development activities. InstaSlice's emulator mode allows users to create hypothetical GPU capacity in the cluster by setting GPU profiles in the InstaSlice CR. This showcases InstaSlice's unique placement capabilities and enables development without needing physical GPUs in the cluster.
+
+## Steps to Use Emulator Mode in OpenShift 4.18
+
+We use Kustomize to enable emulator mode.
+
+### 1. Ensure the Openshift Cert Manager Operator is Installed
+
+Since OpenShift 4.18 does not yet have the Openshift Cert Manager Operator available in its operator catalog, we need to add the 4.17 catalog manually and install that Operator from there.
+
+#### Add OpenShift 4.17 Catalog
+
+1. **Create a namespace for the Cert Manager Operator**:
+
+   ```bash
+   oc create namespace cert-manager-operator
+   ```
+
+2. **Add the 4.17 catalog source**:
+
+   ```yaml
+   apiVersion: operators.coreos.com/v1alpha1
+   kind: CatalogSource
+   metadata:
+     name: rh-operators-417
+     namespace: openshift-marketplace
+   spec:
+     sourceType: grpc
+     image: registry.redhat.io/redhat/redhat-operator-index:v4.17
+     displayName: Red Hat 4.17 Catalog
+     publisher: Red Hat
+     updateStrategy:
+       registryPoll:
+         interval: 1m
+   ```
+
+   Apply this YAML file:
+
+   ```bash
+   oc apply -f <path_to_yaml_file>
+   ```
+
+3. **Create a subscription for the Cert Manager Operator**:
+
+   ```yaml
+   apiVersion: operators.coreos.com/v1
+   kind: OperatorGroup
+   metadata:
+     name: openshift-cert-manager-operator
+     namespace: cert-manager-operator
+   spec:
+     targetNamespaces:
+     - "cert-manager-operator"
+   ---
+   apiVersion: operators.coreos.com/v1alpha1
+   kind: Subscription
+   metadata:
+     name: openshift-cert-manager-operator
+     namespace: cert-manager-operator
+   spec:
+     channel: stable-v1
+     name: openshift-cert-manager-operator
+     source: rh-operators-417
+     sourceNamespace: openshift-marketplace
+     installPlanApproval: Automatic
+     startingCSV: cert-manager-operator.v1.14.0
+   ```
+
+   Apply this YAML file:
+
+   ```bash
+   oc apply -f <path_to_yaml_file>
+   ```
+
+4. **Verify that the Cert Manager Operator is working**:
+
+   You should see similar outputs:
+
+   ```bash
+   $ oc get pods -n cert-manager-operator
+   NAME                                                        READY   STATUS    RESTARTS   AGE
+   cert-manager-operator-controller-manager-77746bc67c-skl7k   2/2     Running   0          63m
+   ```
+
+   ```bash
+   $ oc get pods -n cert-manager
+   NAME                                       READY   STATUS    RESTARTS   AGE
+   cert-manager-5d59ff6b86-67s2l              1/1     Running   0          62m
+   cert-manager-cainjector-6c54b88c7d-dkkbr   1/1     Running   0          63m
+   ```
+
+### 2. Deploy InstaSlice in Emulator Mode
+
+To deploy the InstaSlice operator in emulated mode on OpenShift:
+
+1. **Deploy the operator in emulator mode**:
+
+   Use the following command to deploy the operator:
+
+   ```bash
+   make ocp-deploy-emulated
+   ```
+
+2. **Add GPU capacity to the cluster**:
+
+   Apply the fake GPU capacity configuration:
+
+   ```bash
+   oc apply -f test/e2e/resources/instaslice-fake-capacity.yaml
+   ```
+
+3. **Verify that the InstaSlice object exists**:
+
+   ```bash
+   oc describe instaslice
+   ```
+
+4. **Submit an emulator pod**:
+
+   Use the following command to submit an emulator pod:
+
+   ```bash
+   oc apply -f samples/emulator-pod.yaml
+   ```
+
+### 3. Check Allocation and Prepared Sections of the InstaSlice Object
+
+- Allocation Section shows the placement decisions made by InstaSlice using the `firstfit` algorithm.
+- Prepared Section is a mock, as no real GPU exists. CI and GI for any pod submissions are always 0.
+
+### 4. Undeploy the Operator
+
+To undeploy the operator:
+
+```bash
+make ocp-undeploy-emulated
+```
+
+


### PR DESCRIPTION
This PR adds support for running emulated mode in OCP 4.18. 