### PR TITLE
Fix the makefile target for openshift emulated mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ ocp-deploy: manifests kustomize ## Deploy controller to the K8s cluster specifie
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG} daemonset=${IMG_DMST}
 	$(KUBECTL) apply -f config/rbac/instaslice-operator-scc.yaml
 	$(KUBECTL) apply -f config/rbac/openshift_scc_cluster_role_binding.yaml
-	$(KUBECTL) apply -f config/rbac/openshift_role_binding.yaml
+	$(KUBECTL) apply -f config/rbac/openshift_cluster_role.yaml
 	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | $(KUBECTL) apply -f -
 
 .PHONY: deploy-emulated ## Deploy controller in emulator mode
@@ -259,7 +259,7 @@ ocp-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/c
 	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 	$(KUBECTL) delete -f config/rbac/instaslice-operator-scc.yaml
 	$(KUBECTL) delete -f config/rbac/openshift_scc_cluster_role_binding.yaml
-	$(KUBECTL) apply -f config/rbac/openshift_role_binding.yaml
+	$(KUBECTL) apply -f config/rbac/openshift_cluster_role.yaml
 
 .PHONY: undeploy-emulated
 undeploy-emulated: KUSTOMIZATION=emulator ## Undeploy controller deployed in emulator mode


### PR DESCRIPTION
While addressing [this comment](https://github.com/openshift/instaslice-operator/pull/130#discussion_r1780000798) corresponding `Makefile` changes weren't made. This leads to emulated mode target in the `Makefile` being broken due to incorrect filename. This PR fixes that `Makefile` target. 