### PR TITLE
Fix failures while running `make test-e2e`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # codeflare.dev/instaslice-operator-bundle:$VERSION and codeflare.dev/instaslice-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= quay.io/amalvank/instaslicev2
+IMG_TAG ?= latest
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -55,8 +56,8 @@ endif
 OPERATOR_SDK_VERSION ?= v1.34.1
 
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE)-controller:latest
-IMG_DMST ?= $(IMAGE_TAG_BASE)-daemonset:latest
+IMG ?= $(IMAGE_TAG_BASE)-controller:$(IMG_TAG)
+IMG_DMST ?= $(IMAGE_TAG_BASE)-daemonset:$(IMG_TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.3
 
@@ -139,7 +140,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
-	go test ./test/e2e/ -v -ginkgo.v --timeout 20m
+	@export IMG_TAG=test-e2e; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
-        imagePullPolicy: Always
+        #imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: true
@@ -129,7 +129,7 @@ spec:
         - --leader-elect=false
         name: daemonset
         image: daemonset:latest
-        imagePullPolicy: Always
+        #imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: true

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -76,10 +77,14 @@ var _ = Describe("controller", Ordered, func() {
 		It("should run successfully", func() {
 			var err error
 
-			var controllerIMG = "quay.io/amalvank/instaslicev2-controller:latest"
-
-			var daemonsetIMG = "quay.io/amalvank/instaslicev2-daemonset:latest"
-
+			tag := os.Getenv("IMG_TAG")
+			if tag == "" {
+				tag = "latest"
+			}
+			var (
+				controllerIMG = "quay.io/amalvank/instaslicev2-controller:" + tag
+				daemonsetIMG  = "quay.io/amalvank/instaslicev2-daemonset:" + tag
+			)
 			By("building the Operator images")
 			cmd := exec.Command(
 				"make",


### PR DESCRIPTION
1. Add a generic name to the instaslice container images just to ensure no images from a specific individual repos are pulled by accident
2. Add an image tag variable to run e2e tests

/cc @harche @asm582 @rphillips 