### PR TITLE
Support running e2e tests on an OCP cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,12 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e:
 	@export IMG_TAG=test-e2e; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
 
+.PHONY: test-e2e-ocp
+# Currently setting the IMG_TAG to "latest" that pulls images from quay.io
+#(TODO) Need to run the tests on the latest built images.
+test-e2e-ocp:
+	@export OCP_MODE="true" IMG_TAG="latest"; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
+
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0
 golangci-lint:

--- a/Makefile
+++ b/Makefile
@@ -138,15 +138,19 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
-.PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
+.PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up using emulator mode
 test-e2e:
-	@export IMG_TAG=test-e2e; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
+	@export IMG_TAG=test-e2e EMULATED="true"; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
 
 .PHONY: test-e2e-ocp
+test-e2e-ocp:
+	@export OCP_MODE="true"; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
+
+.PHONY: test-e2e-ocp-emulated
 # Currently setting the IMG_TAG to "latest" that pulls images from quay.io
 #(TODO) Need to run the tests on the latest built images.
-test-e2e-ocp:
-	@export OCP_MODE="true" IMG_TAG="latest"; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
+test-e2e-ocp-emulated:
+	@export OCP_MODE="true" EMULATED="true" IMG_TAG="latest"; make docker-build; go test ./test/e2e/ -v -ginkgo.v --timeout 20m
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/amalvank/instaslicev2-controller
-  newTag: test-e2e
+  newTag: latest

--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -435,6 +435,10 @@ func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() ([]str
 		os.Exit(1)
 	}
 	log.Info("classical resources obtained are ", "cpu", cpu, "memory", memory)
+	if instaslice == nil {
+		err := fmt.Errorf("unable to get instaslice object")
+		return nil, err
+	}
 	instaslice.Spec.CpuOnNodeAtBoot = cpu
 	instaslice.Spec.MemoryOnNodeAtBoot = memory
 	instaslice.Name = nodeName


### PR DESCRIPTION
This change would help in running the defined e2e tests on the OCP cluster without modifying the existing behavior.
Thus, a prow job can be added to run these e2e tests on OCP

The dependency here is the images that we rely on, while running the e2e tests on an OCP cluster.
These are pulled from @asm582 's quay.io repository today and hence need to be updated periodically to reflect on the correct e2e test results

/cc @asm582 @harche @rphillips  @mamy-CS 