### PR TITLE
remove internal slice cache

### DIFF
--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -217,6 +217,7 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 				for _, migDevice := range createdMigInfos {
 					if migDevice.uuid == allocations.GPUUUID && migDevice.start == allocations.Start {
 						createCiAndGi = false
+						break
 					}
 				}
 				// if ci and gi exist, we need to assign those to the respective allocation
@@ -229,11 +230,11 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 				}
 				for migUuid, migDevice := range createdMigInfos {
 					if migDevice.start == allocations.Start && migDevice.uuid == allocations.GPUUUID {
-						if errCreatingConfigMap := r.createConfigMap(ctx, migUuid, existingAllocations.Namespace, allocations.Resourceidentifier); errCreatingConfigMap != nil {
+						if err := r.createConfigMap(ctx, migUuid, existingAllocations.Namespace, allocations.Resourceidentifier); err != nil {
 							return ctrl.Result{RequeueAfter: requeue1sDelay}, nil
 						}
 
-						if errAddingPrepared := r.createPreparedEntry(ctx, allocations.Profile, allocations.PodUUID, allocations.GPUUUID, migDevice.giInfo.Id, migDevice.ciInfo.Id, &instaslice, migUuid); errAddingPrepared != nil {
+						if err := r.createPreparedEntry(ctx, allocations.Profile, allocations.PodUUID, allocations.GPUUUID, migDevice.giInfo.Id, migDevice.ciInfo.Id, &instaslice, migUuid); err != nil {
 							return ctrl.Result{RequeueAfter: requeue1sDelay}, nil
 						}
 

--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -140,9 +140,9 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 
 			allocations.Allocationstatus = inferencev1alpha1.AllocationStatusDeleted
 			updateInstasliceObject.Spec.Allocations[allocations.PodUUID] = allocations
-			errUpdatingAllocation := r.Update(ctx, updateInstasliceObject)
-			if errUpdatingAllocation != nil {
-				log.Error(errUpdatingAllocation, "error updating InstaSlice object for ", "pod", allocations.PodName)
+			err = r.Update(ctx, updateInstasliceObject)
+			if err != nil {
+				log.Error(err, "error updating InstaSlice object for ", "pod", allocations.PodName)
 				return ctrl.Result{Requeue: true}, nil
 			}
 		}


### PR DESCRIPTION
We can now walk MIGs; we do not need an internal slice cache. This is a step further to make the daemon set stateless. This PR removes the cache that was present in the system before the redesign.

`make test`, `make test-e2e`, `make lint` and daemonset shell scripts pass locally.