### PR TITLE
miscellaneous fixes for demo

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -27,7 +27,6 @@ const (
 	emulatorModeTrue                 = "true"
 	AttributeMediaExtensions         = "me"
 	instaSliceOperatorNamespace      = "instaslice-system"
-	operatorDeployNamespace          = "instaslice-system"
 	NvidiaMIGPrefix                  = "nvidia.com/mig-"
 	NodeLabel                        = "kubernetes.io/hostname"
 	multipleContainersUnsupportedErr = "multiple containers per pod not supported"

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -26,7 +26,7 @@ const (
 	emulatorModeFalse                = "false"
 	emulatorModeTrue                 = "true"
 	AttributeMediaExtensions         = "me"
-	instaSliceOperatorNamespace      = "default"
+	instaSliceOperatorNamespace      = "instaslice-system"
 	operatorDeployNamespace          = "instaslice-system"
 	NvidiaMIGPrefix                  = "nvidia.com/mig-"
 	NodeLabel                        = "kubernetes.io/hostname"

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -485,6 +485,9 @@ func createInstaSliceDaemonSet(namespace string) *appsv1.DaemonSet {
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsNonRoot: func(b bool) *bool { return &b }(false),
 					},
+					NodeSelector: map[string]string{
+						"nvidia.com/mig.capable": "true",
+					},
 					Containers: []v1.Container{
 						{
 							Name:  daemonSetName,

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -81,11 +81,11 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// 1. Ensure DaemonSet is deployed
 	daemonSet := &appsv1.DaemonSet{}
-	err := r.Get(ctx, types.NamespacedName{Name: instasliceDaemonsetName, Namespace: operatorDeployNamespace}, daemonSet)
+	err := r.Get(ctx, types.NamespacedName{Name: instasliceDaemonsetName, Namespace: instaSliceOperatorNamespace}, daemonSet)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// DaemonSet doesn't exist, so create it
-			daemonSet = createInstaSliceDaemonSet(operatorDeployNamespace)
+			daemonSet = createInstaSliceDaemonSet(instaSliceOperatorNamespace)
 			err = r.Create(ctx, daemonSet)
 			if err != nil {
 				log.Error(err, "Failed to create DaemonSet")
@@ -104,7 +104,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	listOptions := &client.ListOptions{
 		LabelSelector: labelSelector,
-		Namespace:     operatorDeployNamespace,
+		Namespace:     instaSliceOperatorNamespace,
 	}
 
 	if err := r.List(ctx, &podList, listOptions); err != nil {

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -194,7 +194,7 @@ func TestInstasliceDaemonsetCreation_Reconcile(t *testing.T) {
 			daemonSet = &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instaslice-operator-controller-daemonset",
-					Namespace: operatorDeployNamespace,
+					Namespace: instaSliceOperatorNamespace,
 				},
 				Spec: appsv1.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{
@@ -215,7 +215,7 @@ func TestInstasliceDaemonsetCreation_Reconcile(t *testing.T) {
 			req = ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "instaslice-operator-controller-daemonset",
-					Namespace: operatorDeployNamespace,
+					Namespace: instaSliceOperatorNamespace,
 				},
 			}
 		})

--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -90,13 +90,20 @@ type MigDeviceInfo struct {
 func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
 	nodeName := os.Getenv("NODE_NAME")
+
+	if req.Name != nodeName {
+		return ctrl.Result{}, nil
+	}
+
 	nsName := types.NamespacedName{
 		Name:      nodeName,
-		Namespace: "default",
+		Namespace: instaSliceOperatorNamespace,
 	}
+
 	var instaslice inferencev1alpha1.Instaslice
 	if err := r.Get(ctx, nsName, &instaslice); err != nil {
-		log.Error(err, "Error listing Instaslice")
+		log.Error(err, "error getting Instaslice object with ", "name", nodeName)
+		return ctrl.Result{}, err
 	}
 
 	emulatorMode := os.Getenv("EMULATOR_MODE")
@@ -207,6 +214,7 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 					// MIG walking can fail but at this point we are unsure if slices exists
 					// hence we optimistically try to create ci and gi.
 					log.Error(err, "walking MIG devices failed")
+					return ctrl.Result{}, err
 				}
 				// we should skip ci and gi creation for cases where etcd update fails or configmap creation
 				// fails.
@@ -229,6 +237,7 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 						if err := r.createConfigMap(ctx, migUuid, existingAllocations.Namespace, allocations.Resourceidentifier); err != nil {
 							return ctrl.Result{RequeueAfter: requeue1sDelay}, nil
 						}
+						log.Info("done creating mig slice for ", "pod", allocations.PodName, "parentgpu", allocations.GPUUUID, "miguuid", migUuid)
 						break
 					}
 				}
@@ -239,16 +248,8 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 			}
 
 			if updatedAllocation, ok := updateInstasliceObject.Spec.Allocations[allocations.PodUUID]; ok {
-				// updated object is still in creating status, chances are user has not yet deleted
-				// set status to created.
-				if updatedAllocation.Allocationstatus == existingAllocations.Allocationstatus {
-					existingAllocations.Allocationstatus = inferencev1alpha1.AllocationStatusCreated
-				} else {
-					// Add the new allocation status which is not created and let the daemonset handle in next reconcile
-					log.Info("allocation status changed for ", "pod", allocations.PodName, "status", updatedAllocation.Allocationstatus)
-					existingAllocations.Allocationstatus = updatedAllocation.Allocationstatus
-				}
-				updateInstasliceObject.Spec.Allocations[allocations.PodUUID] = existingAllocations
+				updatedAllocation.Allocationstatus = inferencev1alpha1.AllocationStatusCreated
+				updateInstasliceObject.Spec.Allocations[allocations.PodUUID] = updatedAllocation
 				err = r.Update(ctx, updateInstasliceObject)
 				if err != nil {
 					return ctrl.Result{Requeue: true}, nil
@@ -265,16 +266,6 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 // TODO: split this method into two methods.
 func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allocation inferencev1alpha1.AllocationDetails) error {
 	log := logr.FromContext(ctx)
-
-	podMigUuid, err := r.readConfigMap(ctx, allocation.Namespace, allocation.Resourceidentifier)
-	if err != nil {
-		// configmap deleted in previous cycle
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	log.Info("mig uuid obtained from config map with", "value", podMigUuid)
 	ret := nvml.Init()
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("unable to init NVML %v", ret)
@@ -298,37 +289,39 @@ func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allo
 		return fmt.Errorf("unable walk migs %v", err)
 	}
 
-	for migUuid, migdevice := range migInfos {
-		if podMigUuid != migUuid {
-			continue
-		}
-		log.Info("deleting ci and gi for", "pod", allocation.PodName)
-		gi, ret := parent.GetGpuInstanceById(int(migdevice.giInfo.Id))
-		if ret != nvml.SUCCESS {
-			log.Error(ret, "error obtaining gpu instance for ", "poduuid", allocation.PodName)
-			if ret == nvml.ERROR_NOT_FOUND {
-				return fmt.Errorf("unable to find gi %v", ret)
-			}
-		}
-		ci, ret := gi.GetComputeInstanceById(int(migdevice.ciInfo.Id))
-		if ret != nvml.SUCCESS {
-			log.Error(ret, "error obtaining computer instance for ", "poduuid", allocation.PodName)
-			if ret == nvml.ERROR_NOT_FOUND {
-				return fmt.Errorf("unable to find gi %v", ret)
-			}
-		}
-		ret = ci.Destroy()
-		if ret != nvml.SUCCESS {
-			return fmt.Errorf("unable to destroy ci %v for %v", ret, allocation.PodName)
-		}
+	for _, migdevice := range migInfos {
+		// if podMigUuid != migUuid {
+		// 	continue
+		// }
+		if migdevice.uuid == allocation.GPUUUID && migdevice.start == allocation.Start {
 
-		ret = gi.Destroy()
-		if ret != nvml.SUCCESS {
-			return fmt.Errorf("unable to destroy gi %v for %v", ret, allocation.PodName)
+			log.Info("deleting ci and gi for", "pod", allocation.PodName)
+			gi, ret := parent.GetGpuInstanceById(int(migdevice.giInfo.Id))
+			if ret != nvml.SUCCESS {
+				log.Error(ret, "error obtaining gpu instance for ", "poduuid", allocation.PodName)
+				if ret == nvml.ERROR_NOT_FOUND {
+					return fmt.Errorf("unable to find gi %v", ret)
+				}
+			}
+			ci, ret := gi.GetComputeInstanceById(int(migdevice.ciInfo.Id))
+			if ret != nvml.SUCCESS {
+				log.Error(ret, "error obtaining computer instance for ", "poduuid", allocation.PodName)
+				if ret == nvml.ERROR_NOT_FOUND {
+					return fmt.Errorf("unable to find gi %v", ret)
+				}
+			}
+			ret = ci.Destroy()
+			if ret != nvml.SUCCESS {
+				return fmt.Errorf("unable to destroy ci %v for %v", ret, allocation.PodName)
+			}
+
+			ret = gi.Destroy()
+			if ret != nvml.SUCCESS {
+				return fmt.Errorf("unable to destroy gi %v for %v", ret, allocation.PodName)
+			}
+			break
 		}
-		break
 	}
-
 	return nil
 }
 
@@ -359,7 +352,7 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 		var instaslice inferencev1alpha1.Instaslice
 		typeNamespacedName := types.NamespacedName{
 			Name:      nodeName,
-			Namespace: "default", //TODO: change namespace
+			Namespace: instaSliceOperatorNamespace,
 		}
 		errRetrievingInstaSliceForSetup := r.Get(ctx, typeNamespacedName, &instaslice)
 		if errRetrievingInstaSliceForSetup != nil {
@@ -448,7 +441,7 @@ func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() ([]str
 	instaslice.Spec.CpuOnNodeAtBoot = cpu
 	instaslice.Spec.MemoryOnNodeAtBoot = memory
 	instaslice.Name = nodeName
-	instaslice.Namespace = "default"
+	instaslice.Namespace = instaSliceOperatorNamespace
 	instaslice.Spec.MigGPUUUID = gpuModelMap
 	instaslice.Status.Processed = true
 	//TODO: should we use context.TODO() ?
@@ -697,7 +690,7 @@ func (r *InstaSliceDaemonsetReconciler) createConfigMap(ctx context.Context, mig
 	var configMap v1.ConfigMap
 	err := r.Get(ctx, types.NamespacedName{Name: resourceIdentifier, Namespace: namespace}, &configMap)
 	if err != nil {
-		log.Info("ConfigMap not found, creating for ", "pod", resourceIdentifier, "migGPUUUID", migGPUUUID)
+		log.Info("ConfigMap not found, creating for ", "name", resourceIdentifier, "migGPUUUID", migGPUUUID)
 		configMapToCreate := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceIdentifier,
@@ -924,24 +917,4 @@ func (r *InstaSliceDaemonsetReconciler) createSliceAndPopulateMigInfos(ctx conte
 	}
 
 	return migInfos, nil
-}
-
-// Read configmap and get NVIDIA_VISIBLE_DEVICES value
-func (r *InstaSliceDaemonsetReconciler) readConfigMap(ctx context.Context, namespace string, resourceIdentifier string) (string, error) {
-	log := logr.FromContext(ctx)
-	var configMap v1.ConfigMap
-
-	err := r.Get(ctx, types.NamespacedName{Name: resourceIdentifier, Namespace: namespace}, &configMap)
-	if err != nil {
-		log.Error(err, "ConfigMap not found for", "resourceIdentifier", resourceIdentifier)
-		return "", err
-	}
-
-	nvidiaVisibleDevices, exists := configMap.Data["NVIDIA_VISIBLE_DEVICES"]
-	if !exists {
-		log.Info("NVIDIA_VISIBLE_DEVICES not found in ConfigMap", "resourceIdentifier", resourceIdentifier)
-		return "", fmt.Errorf("NVIDIA_VISIBLE_DEVICES key not found in ConfigMap %s", resourceIdentifier)
-	}
-
-	return nvidiaVisibleDevices, nil
 }

--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -290,9 +290,6 @@ func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allo
 	}
 
 	for _, migdevice := range migInfos {
-		// if podMigUuid != migUuid {
-		// 	continue
-		// }
 		if migdevice.uuid == allocation.GPUUUID && migdevice.start == allocation.Start {
 
 			log.Info("deleting ci and gi for", "pod", allocation.PodName)

--- a/internal/controller/pod_webhook.go
+++ b/internal/controller/pod_webhook.go
@@ -28,7 +28,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -46,7 +45,7 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 	if err != nil {
 		return admission.Errored(400, fmt.Errorf("could not decode pod: %v", err))
 	}
-	log.FromContext(ctx).Info("webhook got pod ", "name", pod.Name)
+
 	if !hasMIGResource(pod) {
 		return admission.Allowed("No nvidia.com/mig-* resource found, skipping mutation.")
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -44,7 +44,7 @@ import (
 
 var _ = Describe("controller", Ordered, func() {
 	var namespace string = "instaslice-system"
-	var defaultNamespace string = "default"
+	var defaultNamespace string = namespace
 
 	BeforeAll(func() {
 		fmt.Println("Setting up Kind cluster")
@@ -506,7 +506,7 @@ var _ = Describe("controller", Ordered, func() {
 
 			Eventually(func() bool {
 				// Retrieve the Instaslice object
-				cmd := exec.Command("kubectl", "get", "instaslice", "kind-control-plane", "-n", "default", "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "kind-control-plane", "-n", "instaslice-system", "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					fmt.Printf("Failed to retrieve the Instaslice object: %s\n", string(output))
@@ -529,13 +529,13 @@ var _ = Describe("controller", Ordered, func() {
 				}
 
 				return true
-			}, "60s", "5s").Should(BeTrue(), "Not all allocations are in the 'ungated' state after the timeout")
+			}, "100s", "5s").Should(BeTrue(), "Not all allocations are in the 'ungated' state after the timeout")
 		})
 		It("should verify that the Kubernetes node has the specified resource and matches total GPU memory", func() {
 			instasliceQuotaResourceName := "instaslice.redhat.com/accelerator-memory-quota"
 			// Step 1: Get the total GPU memory from the Instaslice object
 			By("Getting the Instaslice object")
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", "default", "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", "instaslice-system", "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -619,7 +619,7 @@ var _ = Describe("controller", Ordered, func() {
 		// there should be no allocations in InstaSlice object.
 		It("should verify that there are no allocations on the Instaslice object", func() {
 			Eventually(func() error {
-				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "default", "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "instaslice-system", "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to get Instaslice object: %s", string(output))
@@ -652,7 +652,7 @@ var _ = Describe("controller", Ordered, func() {
 		// there should be no allocations in InstaSlice object.
 		It("should verify that there are no allocations on the Instaslice object", func() {
 			Eventually(func() error {
-				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "default", "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "instaslice-system", "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to get Instaslice object: %s", string(output))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -44,7 +44,6 @@ import (
 
 var _ = Describe("controller", Ordered, func() {
 	var namespace string = "instaslice-system"
-	var defaultNamespace string = namespace
 
 	BeforeAll(func() {
 		fmt.Println("Setting up Kind cluster")
@@ -150,7 +149,7 @@ var _ = Describe("controller", Ordered, func() {
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", output))
 
-			checkCmd := exec.Command("kubectl", "describe", "instaslice", "-n", defaultNamespace)
+			checkCmd := exec.Command("kubectl", "describe", "instaslice", "-n", namespace)
 			output, err = checkCmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Resource not found: %s", output))
 		})
@@ -179,7 +178,7 @@ var _ = Describe("controller", Ordered, func() {
 			outputPod, err := cmdPod.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", outputPod))
 			Eventually(func() error {
-				cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("Failed to get Instaslice object: %s", string(output))
@@ -237,7 +236,7 @@ var _ = Describe("controller", Ordered, func() {
 			}
 
 			Eventually(func() error {
-				cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to get Instaslice object: %s", string(output))
@@ -286,7 +285,7 @@ var _ = Describe("controller", Ordered, func() {
 			outputPod, err := cmdPod.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", outputPod))
 
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -316,7 +315,7 @@ var _ = Describe("controller", Ordered, func() {
 			outputPod, err := cmdPod.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", outputPod))
 
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -349,7 +348,7 @@ var _ = Describe("controller", Ordered, func() {
 			outputPod, err := cmdPod.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", outputPod))
 
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -392,7 +391,7 @@ var _ = Describe("controller", Ordered, func() {
 			outputPod, err := cmdPod.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", outputPod))
 
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -434,7 +433,7 @@ var _ = Describe("controller", Ordered, func() {
 			outputPod, err := cmdPod.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to apply YAML: %s", outputPod))
 
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", defaultNamespace, "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -506,7 +505,7 @@ var _ = Describe("controller", Ordered, func() {
 
 			Eventually(func() bool {
 				// Retrieve the Instaslice object
-				cmd := exec.Command("kubectl", "get", "instaslice", "kind-control-plane", "-n", "instaslice-system", "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "kind-control-plane", "-n", namespace, "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					fmt.Printf("Failed to retrieve the Instaslice object: %s\n", string(output))
@@ -535,7 +534,7 @@ var _ = Describe("controller", Ordered, func() {
 			instasliceQuotaResourceName := "instaslice.redhat.com/accelerator-memory-quota"
 			// Step 1: Get the total GPU memory from the Instaslice object
 			By("Getting the Instaslice object")
-			cmd := exec.Command("kubectl", "get", "instaslice", "-n", "instaslice-system", "-o", "json")
+			cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get Instaslice object: "+string(output))
 
@@ -619,7 +618,7 @@ var _ = Describe("controller", Ordered, func() {
 		// there should be no allocations in InstaSlice object.
 		It("should verify that there are no allocations on the Instaslice object", func() {
 			Eventually(func() error {
-				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "instaslice-system", "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to get Instaslice object: %s", string(output))
@@ -652,7 +651,7 @@ var _ = Describe("controller", Ordered, func() {
 		// there should be no allocations in InstaSlice object.
 		It("should verify that there are no allocations on the Instaslice object", func() {
 			Eventually(func() error {
-				cmd := exec.Command("kubectl", "get", "instaslice", "-n", "instaslice-system", "-o", "json")
+				cmd := exec.Command("kubectl", "get", "instaslice", "-n", namespace, "-o", "json")
 				output, err := cmd.CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to get Instaslice object: %s", string(output))

--- a/test/e2e/resources/instaslice-fake-capacity.yaml
+++ b/test/e2e/resources/instaslice-fake-capacity.yaml
@@ -4,7 +4,7 @@ items:
   kind: Instaslice
   metadata:
     name: kind-control-plane
-    namespace: default
+    namespace: instaslice-system
   spec:
     cpuonnodeatboot: 72
     memoryonnodeatboot: 1000000000


### PR DESCRIPTION
This PR has changes that enable the system to be demo-ready.
- Moves InstaSlice CR to namespace `instaslice-system`, 
- Removes noisy logging, adds ci gi logger statements per pod as we do not have prepared and makes debugging easier,
- test cases are fixed to consume CR from the new namespace, 
- Moves daemonset away from configmap consumption to delete ci and gi if we ever move away from `envFrom: configmap` design then the transition is seamless and 
- A few bug fixes discovered when running the system on a multi-node openshift cluster. 

`make-test`, `make test-e2e`, `make lint` and daemonset shell scripts all pass locally.