### PR TITLE
Add downstream specific dockerfiles and bundle dir

### DIFF
--- a/.tekton/instaslice-operator-bundle-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: /bundle.Dockerfile
+    value: /bundle-ocp.Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/instaslice-operator-bundle-push.yaml
+++ b/.tekton/instaslice-operator-bundle-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-bundle:{{revision}}
   - name: dockerfile
-    value: /bundle.Dockerfile
+    value: /bundle-ocp.Dockerfile
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/instaslice-operator-pull-request.yaml
+++ b/.tekton/instaslice-operator-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Dockerfile.controller
+    value: Dockerfile.ocp
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/instaslice-operator-push.yaml
+++ b/.tekton/instaslice-operator-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/dynamicacceleratorslicer/instaslice-operator:{{revision}}
   - name: dockerfile
-    value: Dockerfile.controller
+    value: Dockerfile.ocp
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,51 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS build
+
+#ENV GOPATH=/go
+#ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY . .
+
+# Copy the go source
+COPY cmd/controller/main.go cmd/controller/main.go
+COPY api/ api/
+COPY internal/controller/instaslice_controller.go internal/controller/instaslice_controller.go
+COPY internal/controller/pod_webhook.go internal/controller/pod_webhook.go
+COPY internal/controller/capacity.go internal/controller/capacity.go
+COPY internal/controller/constants.go internal/controller/constants.go
+COPY internal/controller/utils.go internal/controller/utils.go
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN go build -mod=readonly -o bin/manager cmd/controller/main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-micro
+WORKDIR /
+COPY --from=build /workspace/bin/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+
+ARG NAME=instaslice-operator
+ARG DESCRIPTION="The Instaslice operator."
+
+LABEL com.redhat.component=$NAME
+LABEL description=$DESCRIPTION
+LABEL io.k8s.description=$DESCRIPTION
+LABEL io.k8s.display-name=$NAME
+LABEL name=$NAME
+LABEL summary=$DESCRIPTION
+LABEL distribution-scope=public
+LABEL release="1"
+LABEL url="https://access.redhat.com/"
+LABEL vendor="Red Hat, Inc."
+LABEL version="1"
+LABEL maintainer="Red Hat"
+
+# Licenses
+
+COPY LICENSE /licenses/LICENSE

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,14 @@ endif
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | sed -e "s|<IMG>|$(IMG)|g" | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(KUSTOMIZE) build config/manifests | sed -e "s|<IMG>|$(IMG)|g" | sed -e "s|<IMG_DMST>|$(IMG_DMST)|g" | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(OPERATOR_SDK) bundle validate ./bundle
+
+.PHONY: bundle-ocp
+bundle-ocp: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	$(KUSTOMIZE) build config/manifests | sed -e "s|<IMG>|$(IMG)|g" | sed -e "s|<IMG_DMST>|$(IMG_DMST)|g" | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS) --output-dir bundle-ocp
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/bundle-ocp.Dockerfile
+++ b/bundle-ocp.Dockerfile
@@ -1,0 +1,20 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=instaslice-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle-ocp/manifests /manifests/
+COPY bundle-ocp/metadata /metadata/
+COPY bundle-ocp/tests/scorecard /tests/scorecard/

--- a/bundle-ocp/manifests/inference.redhat.com_instaslices.yaml
+++ b/bundle-ocp/manifests/inference.redhat.com_instaslices.yaml
@@ -1,9 +1,10 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: instaslice-system/instaslice-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.16.4
+  creationTimestamp: null
   name: instaslices.inference.redhat.com
 spec:
   group: inference.redhat.com
@@ -143,3 +144,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle-ocp/manifests/instaslice-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle-ocp/manifests/instaslice-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: instaslice-operator
+    control-plane: controller-manager
+  name: instaslice-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle-ocp/manifests/instaslice-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-ocp/manifests/instaslice-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: instaslice-operator
+  name: instaslice-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle-ocp/manifests/instaslice-operator-webhook-service_v1_service.yaml
+++ b/bundle-ocp/manifests/instaslice-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: instaslice-operator
+  name: instaslice-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -1,0 +1,354 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "inference.redhat.com/v1alpha1",
+          "kind": "Instaslice",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "instaslice-operator",
+              "app.kubernetes.io/instance": "instaslice-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "instaslice",
+              "app.kubernetes.io/part-of": "instaslice-operator"
+            },
+            "name": "instaslice-sample"
+          },
+          "spec": null
+        }
+      ]
+    capabilities: Basic Install
+    categories: Drivers and plugins
+    containerImage: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9:0.1.0
+    createdAt: "2024-11-01T14:26:33Z"
+    description: InstaSlice works with GPU operator to create mig slices on demand
+    operators.operatorframework.io/builder: operator-sdk-v1.34.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/openshift/instaslice-operator
+    support: https://github.com/openshift/instaslice-operator/issues
+  name: instaslice-operator.v0.1.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Instaslice
+      name: instaslices.inference.redhat.com
+      version: v1alpha1
+  description: "### Introduction\nInstaSlice works with GPU operator to create mig
+    slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA GPU drivers and
+    CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation)
+    on the host.\n2. Install the [NVIDIA Container Toolkit (CTK)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).\n3.
+    Configure the NVIDIA Container Runtime as the default Docker runtime:\n      `sudo
+    nvidia-ctk runtime configure --runtime=docker --set-as-default`\n4. Restart Docker
+    to apply the changes:\n      `sudo systemctl restart docker`\n5. Configure the
+    NVIDIA Container Runtime to use volume mounts to select devices to inject into
+    a container:\n      `sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true
+    --in-place`\n      This sets accept-nvidia-visible-devices-as-volume-mounts=true
+    in the /etc/nvidia-container-runtime/config.toml file\n6. Enable MIG on the GPU\n
+    \     Check if MIG is enabled on the host GPU - look for Enabled in the third
+    row of the nvidia GPU table, while running `nvidia-smi`\n7. Create symlink in
+    the control-plane container\n      `docker exec -ti kind-control-plane ln -s /sbin/ldconfig
+    /sbin/ldconfig.real`\n8. Unmount the nvidia devices in the control-plane container\n
+    \     `docker exec -ti kind-control-plane umount -R /proc/driver/nvidia`\n9. Install
+    the GPU Operator\n      `helm upgrade --install --wait gpu-operator -n gpu-operator
+    --create-namespace nvidia/gpu-operator \\\n        --set mig.strategy=mixed \\\n
+    \       --set cdi.enabled=true \\\n        --set migManager.enabled=false \\\n
+    \       --set migManager.config.default=\"\"`\n10. Deploy cert manager\n      `kubectl
+    apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml`\n
+    \     \n### API Backward Compatibility\n**NOTE:**  Until Operator supports **seamless
+    upgrades**, a new version of\nthe operator may introduce a change that is **NOT**
+    backwards compatible with\nthe previous version. Thus, to upgrade the operator,
+    uninstall the already\ninstalled version completely (including CRDs) and install
+    the new version.\nFor example to upgrade from 0.1.0 to 0.2.0, you must uninstall
+    `0.1.0` by\nfollowing [uninstall operator section](https://github.com/openshift/instaslice-operator)\nand
+    install the new version.\n\nChanges to patch version (major.minor.patch) indicates
+    that no breaking changes\nare introduced, thus upgrade can be done without uninstalling
+    and reinstalling\nthe operator.\n\n### Documentation\nDocumentation and installation
+    guide can be found below:\n  * [Installation Guide](https://github.com/openshift/instaslice-operator)\n
+    \ * [Instaslice Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n###
+    License\ninstaslice-operator is licensed under the Apache 2.0 license"
+  displayName: Instaslice
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAaUAAACGCAYAAAB9nZWCAAABVmlDQ1BJQ0MgUHJvZmlsZQAAKJF1kDFIQmEUhT/LMLQiyCVosCUKVMSkpgaTiKDANLPans+XRmqPpxFCS0N7U0PQFo2tBhG11xYURNDaHrikvO7TSi364XA/Due/XA509Sq6nrMD+ULJiM3PetbWNzyON5wM0M80fkUt6uFodFEifM/OV33EZs0Hn7XLHfYenGi18e27m6XrUZ/9b77jOdNaUZVZEwVU3SiBzSsc3SvpFu8Luw05SvjI4kyTzyxONfmykVmJRYTvhQfVrJIWfhH2ptr8TBvnc7vq1w3W9X1aIRG39ohGCBMnIfKwyhxB6WHqn3yokY+wg04Zgy0yZCnJz7A4Ojk04QUKqPjxCgcJiEJWz7/7a3llP8y8Qtdyy0uewsUVDCdb3pgLhjSoHOqKofy0aqvai5uTwSa7KtBzbJrvSXBMQP3JND8qplk/h+5nuK1+ApGsYaAEw40HAAAAVmVYSWZNTQAqAAAACAABh2kABAAAAAEAAAAaAAAAAAADkoYABwAAABIAAABEoAIABAAAAAEAAAGloAMABAAAAAEAAACGAAAAAEFTQ0lJAAAAU2NyZWVuc2hvdMAe4g4AAAHWaVRYdFhNTDpjb20uYWRvYmUueG1wAAAAAAA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJYTVAgQ29yZSA2LjAuMCI+CiAgIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgICAgIDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiCiAgICAgICAgICAgIHhtbG5zOmV4aWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vZXhpZi8xLjAvIj4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjEzNDwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj40MjE8L2V4aWY6UGl4ZWxYRGltZW5zaW9uPgogICAgICAgICA8ZXhpZjpVc2VyQ29tbWVudD5TY3JlZW5zaG90PC9leGlmOlVzZXJDb21tZW50PgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4K8YXU9QAAQABJREFUeAHtnUuIfNtVxut/vQNDcOBMkhDwhYKPgA80iVMjouJIjE/QmQ50YiRPEMyNN0YDDtSRD3zEBEdBUK4DA4og0YQbk4ADdaDEeeJAAwGtr7p/p75atfbznOqu7tuHW/9v77XX9621d50+q/Y51X2ffc/3fM//7VYcz549W8He7dbw13CV9Br+Gu7a2E/8de/dFuu3hcbac2iLHB6bxlbzuUYd5aRji/PmRunm36310J7Vff7//u+0JklINkeCZHjkqzj189CC7/GIj08J4Wrc+SX/aF/Dd+5M/Cd++byL71PWv+/1U06ew5bnn3Sl13N4DvL3PHp1XGOGr7iuEfNQv+dwjdk8FMd1iOt62FroOs6X3fsjOvg6Hz3GWuh54et62HqxpUd+4Crd3b6+NOrE8wqgCflBH/SxrH30u9E59jPvU5v70gZPPfOe+3o79z61Rv/YP/U+70X/2D9nnFqif+yfep/3on/snzNOLdE/9k+9z3vRP/bPGaeW6B/7p97nvegf++eMU0v0j/1T77znHG/n3udW59AGz71zS/SnD+asU6v70gZPPcu96B/7ZeZxxDm0waNXu5VxMltLyTm0I7Y0GIcX+9HOeAsjL/Zb/Dge+fQjRl6rDx+/Z/vCpCPaGX9ODSolyGAvwgN7efITBx54V3xiExfsjX8NfNbQcSR/583M/775vAeex8j81/CJybqBvfG34KOR4Vge59eB0fncrOW5zlge59eD0TxYC3gR7yMfz2lNPp67dHih7+OjbbRifvRH9fAf1T3slCCXKhfjJYQHlvxKdnhgyS+zO8fbmW9mc463M9/M5hxvZ76ZzTneznyjDf+I0a/Ujzz6Jf9oxz9i9Gv11/DhKoa3WzEZd463GW+hc7zd4vk4PNDHRtrwwRHuvpQs6wcfHNG5uelS/yTc0iNuxBYvjkc+/ejX24cP9vKiH3wwjo/0XcPbIxrRF52I0W+239JdilKshiLKhkAtgciV713xY2yP25P/Q+bH3OO6t+Z/33zlG3N46O+f5qTD53FjKf8b12CUL/+o4fH3P8b7fMrxGXGNU/7tdUCPARs6roGu0PXcnrUzjRN+Rx7SbeloXLo9R9TyfEZ0evLafz5orjM5x7ywXzI/5gsSswd78l2KUvbmZLZS4Mw3s2X8kl/JHjWiH30w+sd+9KMPRn/vZz7YQPeP7cwHGxg53s98sIHuH9uZDzYwcryf+WAD3T+2Mx9sYOTEfvSjD0b/2I9+9MHoH/slv5I98tXPfDNbxsUW/el3XncPMnDUoQ22ClIpj5ad8YhL3NuBpd9XRxa5hRd0on0hFBrRnz5YoKXmjLPYBuenAAvXomEDbairGXn0I3aJBSc03Izt8ExJA6pgVLGITiy11/AP8fafDmbiknuGpVyjPcalH/2yvnzxBzO/ku2Jv279tK6se8TSmkd75NGPfqW+/HnJBz5Y4rl9LZ+4mY7HabUz/sg8yKOGrRwYJxfig4z3IrwSjuhIY62O4qEDYuvNJfqhA67Vg5/pycb4oTHxD7qg6y07JRmpVBF7YsLJdHr4+hTW+lZGS4ccwJY/4/hHZLyFszx0n/g3Hw1ZB9alF+FF7OXjt4YPV1q0QfRbiH/EFs/H4crmbfdpteFFbPHieOTTj361vnO8XeOUxuBHLPmX7JFPv+RfszvX2zVObcw1vF3jtMbQKWGL3xqPuidFiQooETmqD6El7NyHxo+5j+a/JV+Fef9ZbGj9Pb6/b7L3vH9b8vXRYv85cDp/zjOfB7YSev74jPDFiRp3zY85ePze9zFqqD+jE9ci6qjfOqLGTB6KcW06WU6y+fzU7z3i/OBdi57yyXL0/DTufebQi1H/pChJ2I/Y9zHaX/d1X7d7y1vesvu2b/u23etf//rdq171Koae8MpW4Atf+MLu3//933cf//jHdy+99NLu85///JKhv9e0wcWp0jj1Hd/5nPJvAmW2UgqZb2Yr8WWP/rFf427BjxrEB1vxGY/+9EH8apj5ZraahsacQxtscRmP/vRB/HrQObTBHj4+GSez4d/CjJvZWjqMZ9zMhn8vugbtiL1a0W/RefOb33xzgzB4yIEKGIYO3S//8i/f/cIv/MLuh37oh7LhJ9uVr8CXvvSl3R/+4R/uPvzhDx8y9fd7ed8HvgXEdFMdBjvwofOZos8D2whuyV/ez5EEbn09j610JtI4+SROHuBavRl+5Pg6xbGRvuusmV+M6bpxbKbveuQJzug551ksSgrWOl73utftXnjhhd3XfM3XtFyfxq98BT72sY8d3kul2fPe16bz0PnXsAZb5HBNGlvlco06W+a0tZb0dKz9mbxROf/3UrqK9GX7W26/ch7yaFFwKqBQt+c++MEP7r72a7/26PTUerAr8NVf/dW7r/qqr9r9/d///ckc4vs+ehJeJf8edn4sqq8HthHcks/P80h8fD2PrXTQHsEsj83ymThPYu6eXxyb6V9Sb826xbl4nrO6y1fCXVzCvGRXG9Qtu6eCdFiOR/OPngl+//d///Ke+/vN+94zWc6ZWT6xLsZv3wQ4THPtPJxPm7n1rCO+cIXYevn4o0HfsVcLjZgH/R4d14AH9vDxQUd9+BHxbSFaZ/zO88T1XetMzx072lFrrZ5CRk1sjmqPHpfQTYuSKpyOiCpGT8+QRt+2h+H/1re+9fB+6z2P73vvDODO8hUHDdq9sfHL+OSDTwvxj9jiMR55sY9fDcXxl3zRqfF8bC0fLeKeIx5tPOZynAd6bfbRAx1Z4INHr74WWvDBPvapF1qyogOeerZ7aB34+0sxOmBb4dzDNdGJeM5qWy6hmxalWJnpf+/3fm87yyePB7kCr33ta3ff9V3ftXyi0iR430cmxCenWb7zZuJn/K10RtZhizxYS/IHR/JAw/MZ4bsv8Y/oo+32TS7H8wqdNjP3gA/mXnXrTU5zO9GoTB4Ro19v/6CzT20rPcWVVtSj35tXyQ+diCX/kj0tSrH6UVH1te+n4/GuwBve8IbDpzJ//zVb3n+wtgLOxT9ijU88dPR3wNbwFx2bRyt+zGE0/hb8qEE/Q9lKB/MH5feQ58M8mQ/o88KnB+GDM+cbcdC4wfN1ln3kONU7v4MxqqfYmSY6EUdyrWmP6p78npInQbVzm34P6el4vCugb1XqiO89fbC1AtGPPtjixxxm/tJHFiuz1XKJ/rFf48Y5ZP0WP3KIH3GtTg8/5pL1R3XiPOiP6uA/yocndO7M+ZZrne7APIb7t9qRRx9s8bPxjIsNzHg9thK/ZI+a6U4Jp1jhnn4xlpV5nKjfPdMR33f6vbPGP2IvH781fHEjnz76LTz4T+zU0CUH4oKM9yAa8p3hLzGSeYzqkQs8cInR2YAXsZO+uInPS0b0FoeBRqYzqwevhANpHVxLOthH9eQvrr+wzWhFzo3u7fuRnHfRP/aLOyU5UtnASH7qP+4V4H0HR2cLD7xv/lQeuqd/+NNJx5+HkXl4TG/PaMzyFWt/CTr7eZ7Rc463R+aDL3wQ+wg619sjGvjCj8j4COrCHHXoj+jgu7Ueup6Ttxmfx9tblRM/P8WipEXwY9uEXfmpfY0rkL3//oPRyvmS/N48PAedv/Ai1ubiGvLLdEb4+LoOthLGHOQ3wkfXdZy/Zj3Qdj1sNfRc5Of8+8hHOcScZNtntn/N/W23TC+b5yFMxz+ZHjTXxdaDJU3Xk4/3e3TxmdEvFiWJKpGn45W7AvH9j/3WykT/2J/lj+i4L+2Id50H8ciDfgujf+y3+Bp3Du2Iozr4o0O/hdGffsSWjsbhuG9m8/FS+5x3cx08t5cUjvaMgw08eve1SrySvU/1fA3Ri9ir535oZDbGwOYzJVW6UrXzAE/tx7cCvPe8/2DvTO+brzzJgXZv7u7HvCO6T6ud5YFei8s4GvBAxnsQDfnCB3v4+GyhgwbxQWKMIFprvj1HPPIoIX49uOS1d95CTzHR3EqPebR0iYf/CLo2OiWs7pQUlOo1ksCT7+NZAX//vd07Q+d4+674ikNcsDd29IMPxvFWH17EFs/H4crmbfdpteFFbPHieOTTj36tPjyw5V8ah7/mGaBrL3qTf1HDtdS+dj3yLeWJHb9ZRKeEzaJENUNgNpEn3sNcAX//1dZ5AOpT6e13AIqTg4+D8xcdBhNcy5dk1JDN81C/dUSNUb70XcP5sqvfc7iG/Gd0okbU6clDPq6T5dE7L9chtutha+GpzvmzoN58FOdUK1/n+9TLcpTN120kP3E54txlz3Q31d9fSPgyTrMoKZmn45W7Av7+0wZbBYlVW/xvDfRB/EoY/eiDJZ7bM9/M5pzYjv6xH/2zvnNog5l/Zov+9MGME22Zb2aLvNh3Du2IkZP14fhYZvPxUvvIO30WdLSXmOd259COeM4qW+DKg3bEMjsfgc8ofRD7KEY+/Yijuu6PlmzscKvPlOSoaphVTo09HY9/Bfz9nz0P4IGjqwYv4oiOuJFPv1cH/4i9fPmJu4aPRoay9R5LHhO/R+IxFp29kXn5eG8705nVg1fC3pzkV83r9AvKXbJb65Fj9iyN+XclljiRKzolTKjdJmKIgH5zpyRnr2bqPx2vrBXg/QdnZ78Vf1YHXsTR+dw3n3zX5nHQ2W8m+ISKHvq9CA/s5ZX80AFLfi07/IgtXmn8TGflTaQt9bj1pdzPdEsTGrRHXfqDMqm7ChJ6XUWJCpaqPRkf/Qpk779OID+RWosQNbbk9+bhOXj8Xr7m6Brqz+hEjaijfuuIGjN5KMYWOlFDulvlIy0drndjqf+b5RR15CPdniPqeT7ogFN69kwFHbBHTz7yLx2eb8mnZq9pi7dWXxrE6CpKBBU+Ha/MFch+eDNbbXWif+zXuBqL/vTBFj9qwAN7+FHD+yM6mW9mq+UU/emDNa6PRX/6oPvW2tGfPljj+ljJv2R3bmxnHGxg5JT60Z9+xBI/s8PVWNyx+ljGLdlKvJK9pJPZaxq1sUyrZOsuSlSxktBDs//jP/7jIWXhd37ndx7a4EOby13ky/uvE09tx974aMj/PviKSw4en/lovOfAP2IPF58lj+QTMj4tREN+Pp8WL44f5pHkwfyif6m/ZT7E8HmN5iMNcsp0RvXQkm6mJ/vogWamN5ofsdGkL3R9t4+20VYB5ZYheYKjmtG/uyhpUg/9+J3f+Z3dP/3TP+0oSMznd3/3d2kuBernfu7nlvYy+ApvcA5EHFkWuOJ4u1fDOd7u5Xtc+OCIRqYzzd//gLvetM6an9F9Clt8Uve19PbonHw90AFntLbUI4+Is3nBi3r0GR/FyI/9UT33pyDJhi7ofjPt7qJEhZwJcg0cFSQvPqWcKFigdk9PBepmtfwc0AnIJyOwtKZuR2MtH80ZHXJAQ+g6bi+1o8YoX7qu4XzZvV/KAbvrqLTslYf40jnVOF0P8iFeDaMOviPzgeNazicfEP8aupb8Mr0a38eiVlGv4/f40I2aWX4j85Vu1CSWMNP38Z72sH7nenQXpZ4kr9WnVJBUcL7jO75jSVu7KA6KklCvp+J0szI6mTlog9hbiH/EFo9xeLEf7YxnmPlmtoyLLfrHPn41dA7tiDU+Y3Bu+vM7L9ehDRKrBzNOZmtpOYd2xJYG4/BiP9oZb2Hk0QdvN8AtmZPxhbu30o54QujsoOHu2EAfG21nGtjA3vV49EVJBSXukLTz+fmf//nmusOlMFGcfv/3f7/JfawOfDrSiTb6yY01gReR8RZGHv0Wz8fF0eHzGNVBI+ochDv/QcPz6KSeuGU6o/ORYKZzEmigQ/yIAxJpPuiN6MiXuam9dr0voeeanh/zBeU3ejD3THdUK/NHf7+y++HTnfpo3o++KMWCpILS+4UG+eHrBepbvuVbDrf0WoVNOzQd2oFpR+Z6h4EH+o9ObB3g7DTgg6M68MC1/Bkd53h7JBd44AjXfeFHdJ+e9lq+YviFaAs9aV6bjnLSsVVeN2rHf6Mu/aPHXAsdcE4lZ91cGk6vD6NxDkWJEwjMwz1Mq4oJx2hRKHH5wsTP/uzP7rJdU3a7kKKmHB76MyqdJ/HQiTdy/kSNLfm9ecQcNCfPo0cn04g6ca1iP9MYzUOarrPm21GuQ66eD7YWtnQ0Lt2eI2p5PuiALb2oJf9MT38loeeWU69eb37KJ9OUPc1TA53HiO5IvoTfQv9QlDgxQAK8UpDiw66KfjZ/FRXtetj5qDB5kVG/xteYXr23ELMcrsGWnSuZrZZr9I/9Gldj0Z8+2OJnGm7r1Sn5leylvKI/fbDEc7v7rvk2neugn9kYq2Hk0QdrXB+L/vQjOqfWhocPfbCnIMEVLrxbI/2Izmm14bofNtDHetsZF1vEXs3ohw52+hEZB092ShgfK3qxoDhkXxGvzR8ePtopYVNR8xj4ZEgBbN0CzLjXYOMTkU4wPlGBvfmhIX/XuSu+4pCDx99qHlvp9K7HVvNxHWL7+mDrRdahhCM6+Ho+6DLWi+JxuB62USzpzean+Gh6fuiBo3m6Ltyt9WOMEf1nb37zm4/vDBkW8G//9m93zz3X/BuuBfb9mPX8xw8VkVg82P3IT20/vMhQSHxc7U9/+tO7bIeELoVHWvLzQ9xrOT75yU/ufvmXf7k7HZ1oa4+1Gmv5yv9aNLbK5THrbDm3rbWkp2OL8+lG6fjvJTRRv6T2TIxnb3rTmw5FSYm1Ku9DLEqxWLzmNa/Zvfa1rz255cbC9WD2vEia//Vf/3VCV0HKnjfFwnRNt/FGi5JP2M+f1nnkPNprnoGgIVybB1qug20EnT+zHsS6hA7aM3iJfNasD3PwvLCtwUvqbT1f9MA184br80cXxGdL9HjPqaOXDnDLYPet5b+HpFxUPFQs4o6oN0/terS7UTHhiAVJRUqH77LwVVznlnZf+F87ZufP6Hl08N+fgvAittZA/rzkO8qHg8YMnxzRQNMRnxaiEfOg3+IzXtJhvBdLOqP5KB5atB3VHjnQIg9wRANf10IHxGcUXVNc9MBRPTTgl3BG17VLuthn9eFJJ76ILzzci1MF1AEeOg/8H+1osqKgaWls7VErau9973sPX4SIuzRiqrB5YdoiH7TvGnXOcN6AoznAA9fy0QF79OSLf8QePj6ZDmO9GOPT7+XjRy7wQcZ7EV4Je3XkJ42oM8J3X7S20EOLHB095kgbzS3yIy6ant9W+mhHvdgnl1n0OLR9Po/qmZKKEM+L2A3pgv/Rj3707PbaFs9yfuRHfmT3L//yLyfvjd+2U2zlU7pF58+7tsjnJJGJzuztu95PUD/90z+9+9Zv/dazzP75n/95p9enPvWpszEZ3vCGN+x+8id/8mzsT/7kTxZOLYef+qmfKsb94z/+4xPdmg6OmgMv2ZgT85CGcus5NC8/D3o4NR+dR3/6p3+6uPTMZ3GuNEo6v/Zrv7Z7xzveUWGeD5W0zj3bFtfSOn7zN3/z4aU2P1Of+cxnDkJ/9md/1hRE74UXXjjzlY400TtzKBjQ1LDye+tb33rmKU1eZ4OJwTWT4UMc2X/0R3/0MKy4fnzkIx/ZffjDH3bT0pYvvMXY0fAY0terdWTzeJ4qqEG1HVuC1zROAVBR0ImjfvxSgeerseyZj/u02p/73OfOXFxTOyJ9u49bdHzhAZKKFWMqqLXdF5y7wNHzgHPIcyudRyow8ZBNBenll19ehuCrkKmolA4KWcwBvjAraNJTMRFfxYSjpqMLXanAoUeB+omf+InDl0bQ9nyIJZTflofie1GK8yFWKR/GI0Yd8X/8x3/8UFB1MdIFVT6yt46oJX/Pp1dHPPnqffmxH/uxs+Iuuw5QPipMteIkPfn5BfYgsv8H22hR8vlKAx10hbJJ993vfrebi23XdCfpqOhlMdxPRadUBMVt8V0ra0u/pyhl80ifKfWcWFki92FT8dFJx45EF3r6tXxUBMSdPcT/7//+7xN6VlQoUsovxvMiJb1rOXj/wZ685OsvcSKfC3ZJr8WPvKzAoZHFj/xSHw3yF6qwfeADH1h2RSWu25UfWrKj5z531SYPcDYf56so6aCwjs4PLXgRD+KNf973vvft9KLwNNwPBafls/aCXNLX/C6hLV3NX48N9OqNUfL7pm/6ptIULmrXPPR6TpWKagVeNPKG4trtsNPgdl1tdxRDZ4Ui+pT62Scaf07kvFphKnGcf9dtzgOwJ7588Y/Yw5cPGiP8WJjQQK83tvvF+CpIpd2W82KbXKJe9LuLPrko1pp80KEgSU8XxN6iIH8OtGbzGSlGxFyLpQt5jy7z7PEd8dGu5Fd/9Ve7i9GI9l36cj6kO6W7TGQmlnYV+iEQcrtOGAuSLvi6lccrfhNPsWcKk+Jm37jLdkqKITvFR/GyXZH/hXJx7vPQpxUdYG8u+Efs5RNzhJ8VixF+LTfpzBYk6eo2mjS2yqeWa89YzIN+D9d9xPOipLHYd/9aW1rkAdb8GZstSLVbd2g/JNTOKHtG9ZDmEHNddkpUKTlQ0cFIus++PyvSxZ5dSCxIsvvtMeX8B3/wB2nqo4XpF3/xF890dHLUDuVC0fJcsWWFqqZ3qbHsPOiNBZfzJmKPDhryhV/jaadU2i2hxXOnmk4cg5sVveib9fVFBzQO89h/wfWAe+eIGf8StpN8kjzIqxU7K0D6kDizi/CcvK0cSvko/szOTJqjz4PE8YMcZSvl5/4zbXTBTENrPXKrLtO4tK2Wfy324SvhfFrhk0rEmsBdjqkgqYDo8IKkCzoXddm1M+JiH/OjiEV7b2FSDvFZUtQq9dktaZznS6U8SxqXtnMuKA7nwUjMjD+qgz/Yip8VDvIAWxrZeO0LFvLXlxhUfHhlGrId5lH4PSz/UkKJP2Jv6fl6HPIiP8NWvKwoicOzpRY/GycvUD7kF/31RYTSwV2R0hcaNL7m6Mlvjb64zBvM9Hq+zJDx7sqm4l/Lv5bHyd++U2WTEFgj3vVYqSApDwqV2n7hVz8eKgK6jZfdLpOO7KXC5TlkutEW+4qt/BSHnNlBUVQj5677fLqZPQ/W8jVfzj+0WmsQd0r4j+rAA7Nix5j+HBPfrMOm4iSOvtChNofnEde1VNCk8f73vx+JM3z7299++Obg6A8+a+p5kN9ZkMRQKzzaveg1c+HvzatUEJWqCtGHPvShQ9bMT7ZaEUum2DSxXmCTMOiwvwzvr8NlUm9B4tt1FAi9L77DnN01vuc97znbcbLeGZZnko8cihJDEtQBYr9vjMXAi4bvknTB79l56Daevzk+P+np9lrUijk4pycm/ipCFCRsKpLMY0QL/pbo7723R2LAA0e47jvCV2Hy23R+wRjRIX7tm4IqJLEgwfNihA0kDxB7hiV9+WpMrx6dTBsbfBB7DWNR0O8o6XeVODQ++ntLcMkjIuMtpCDJz9//rZ8jzebXyp/xVkFqPUNSsdHvIFGMjrrPzooJY70ozVjM4nrEfq82fstfV9Wb6C85qH8Nh1/E406IMV3M4zOkWu5Rx30pTCpEOlSkiON+tLMvUDCWIbGlSYzM7z5sfg54W7n0ng/Ooz06l1FetqtBQzh6lHZf0qH4jeh6LvAijuRY0+vRqfFLecVdkoqAiqPvjPRhj2dL6PTkI5+Yk/cZRztqZoXH+bT1/0hSG72oo3686LoPOhHlg677j7bRdT10ha2CpGKkbwYzB/QilvRb+X72s589c4naWX8k3lKURFKF40VfeJ+HX7R1MY+FRwVEBxf63lyjTsZT0dAPGTEyH9nW7m7W8kt5zdo5BxylpX7v4dwRnuuP8FREskJCHq67ts1FeCQ/xSQXeBFH8nKtWR3XIL8MySvuknh+BeJH8SIv7L3oedEWV+3SHY6aNhpC/T+SDnirV+OVxlyPtnzRLfF67Jkeuq3bkCpIpb/SgC7o+aIP9uRZ8kE/4ki8k6LkFU4i6t/nEW+ZxUJCsdBF/dou7LV183mo8F1b7rzvEQ//J87axGyMc0kmdGy4qznKq+2WugJ2OnFhHM2PNYEHdoY9c4Mf8cyxYBCPl1zQydwpNIz5rTIVaQq1xrU+etX00MmQnOBHzDilHZR8Z/SyGNhcjzZx8JnFTE+21lErSOKiC2LLULbZA/2I0pMtw4PR/jkpSl7d5LNF5bRYq5rZTohbatlYT7CtisFaHS+uPXnflQ/vPzj7f+Jc+BdOPNspKeTW8dEDR6YlDjxwhO++8CO6T0+7h1/aJaEfd0vyRxefUYQfcVQH/6hDn/EZlAY64IyOc9CJ2Lp15xq1dtSN/Rp3ZEy6vMSLcehHzZOi5NVNjrGyRfKl+xSdUpy1F/PRZ0GlPB6j3c+F2fPANe5qjbLCRP5b5cCODF2wR9/XxNvirtFx/ogOPM8FPljbJYmvI9stsXtBB7xhtP+VPy9/FpQx2Z1lY9jQIo8S4t+DrultcdHv0XEf16FdK0itXZJrq42mI/bou6bv+rHt8TTm/ZOipIFaZTsw7+gfCg7h/JaXbIyv3aWgP4tbxZ/d7c3m3cPjXOATDdjDxQcN+pdGCsbaOHyZIdPRN/MUh/UAM9+SjXUB5bdGx/lrdLJ8Wrsk5hh3SxQz8gHx78Eln9tnQX6bMPJbz1zwJ48S4jeC5AmKi/6ITvRFjwIfx9f20ZfOFvmW8iEO6PGIC54VJSqaSFSwUqBrsM9ezFXUPvaxj62egnT07TyKZI+gf3mjx/++fDgXOA/AkXzQGOGs8S194WFUs/aVbGmpKK0tgKxnxJFcfX3RGeHjm+nIRmHBz58lYQOz3ZI/W5rJL+aVfcuO+IoVCyhjjuRRQvftbcc8xUO/VyPzc91sXLbSlxtK/m53/Z589cdaVSBbL4+hNnFAbBme/J6SHHRQscAb6/3+q4u+70rou62VoTi6JdhbQNBu+WtcL/xVKGmTExr6fzvpxfGN3/iNZ76MXQP6OeDtkdxmeSMx3FfForbTcd9aW79zVCs8jNV+N6mkrx9O1iViiVOyr+VHXdeLF/m4G3rxxRd3+kVeDo3LxiE+uxt0GRtF8Sl8KkDZod2SLpjvfOc7s+ETG/lEPHGa6GytpxRKOyW++j2R5hmFvM8GzEAxMlPazH7BNjoSL2JalLKKCTEKX6ofL+rajeiXZrFnf5Ehy4ViMFKMpKPCwi1DafTwiQVK5yu+4iuqf5ZI/5NAfsDY9RFX/Ps+zs8FfS187C9/nGtcdlbslihM2vVkz5rIggIBYtf/AFC36mq/SOuFKfLRKWG2Lvo521pnRM9zirukWJA0rnNXLwpPLBoa04WMcZ/fbF7arfkv7Mb1Vcy/+Iu/OBQm4kYfn6ePrb3O1XRLYx5/tK2ixDqCoxry3zo3vee1glmLd3b7jgnpzfEX9rtEChAxVZh064vbX1zEGReqIOglX/2fYYV6eaFw/6ytE9kLg/JQQdSuZvQY+Tt5Knx66YeKOY7Gu4S/nwf70+LsE35PzLU/7FkMik42Visk0Z/cQB9/29veVvzrDfipMP36r//6si7Ye/B0bVXwj+vbw3cf13KdbF7Oi210YlGKt+7YRUW/rHihuSYvuLrY1W7jMR/9JXFyxBaRvMA4PttHD5SO2jNHaZeEFrog9vvEkf8nE2sEpjslTYZKJsc1FXjNwqgQxIKiizbHSKGBswa167mrg3l6cbyr2DEO54Lsfj6MnBeuEfVn+zz3yXZB+mOq8X91XorDPMDop8L00ksvRfNJX0VQhUl/E2/kYF1m19VjoSWb67lPT1s6sdCoIPn6+Lg+ROnFrkSol2w6GNf75Xm5Xk9e8mGO5NMqOnz5IRZU4qG3/wi+3/8fb6kyPovowmfe9EeQdSxxWEew5HeX9uwvP5Tix7Uq7pQkoIV0PHTu+J9sN3TpFErF7q6/Qq7CdC07Jp0L8Xygf+n3o6Zfe56TFatMi3mAmY8KU+ugMLX8SuPEB0t+Nbu48MGaf2nMi458tPtxvVgMMn/Xlj/8iO430tZuqWfHpMIU8z2LY3cAzsZWGDTXtfOl2JfSWKtf0r0ve7UoqYLxuq8EdetMb8p9FKc45/g/9ovjpb5u+yl/7fz04pMkqDnqE3Y2R3ZMJe27snMegIqrtuOhs+If9EYkXn755eKXGnje09IjLpj561P+aGGq6cUY8vVXHO/tu4a3xVe/5ygVGPjZBZ7dEPqc2/Q1rttQ5CQ7ekfEu43oqFiWdkGu0ipM6JGLc9e0XZf2Gr3I1Tqj6yg/9R0PnQfwT7UoUeWpxPc5H93G0gVdF+74rKmW18wtN92G8d2S2rqN6N+aq8XUGM+hdNL8+Z//+eEZlWwxd2nrpcKlOco/FifPpRX3kuPxfOC8ANfGntERp7Rb4gsPrbyIC5b8RwtTSy/GkT+vODbSR8NRfPV7jliUuOjDj+NoRvvos6XO9Ah3QOW05Y6JOZ4E2aAjXV4byJ1JoA3KQW3HQ2eDf/RMr/b6yEc+supr6sVnSsqdSqs2E1T7vg4u6rpIq0DpmYEKiB8//MM/vNNLhxcALuzaedB2nrf1jTgVIfFf85rXdBcj+Y8WTeJ6ripO+nYheSpnH4dz1xjPB/Wv4bxgt5TdrtNuiWdPpfViHmDJT3YK0wc+8IGa2+Ebe4pdKpgZOa5v5tNjYx4lrGlkhcV1artPdkv6YKVDqBfPRNgtyabzxnVnzyNp6Bh5xkReB2L4B71gXt1FF1wteCugNVWBQHdf+pZnY7L5Om8Rk78e4bpbx6nulDQJBZ89YbZYhJKGLtjxl19VqPS/CNYFPF7EscmHV+vbdIrRszuSNpoxbil/7NdScMinBzkfwB7OJX2UR+nir0LV+iYe8wBbuaowfd/3fV+z2OkC3oqdxerNI+Ni40KhPnogPhlmRQk/8bNbd4wLa3zGySOi64y00RnZMY3oX7Pv2Tfz7NkY6wL2zuNMs0BEN2LBvdvcLEo6uXl1q17YkR2Eh6HouK3Uxnf0m1KZngqbCtJoMZKW5pHNRWP+pQpva+xiR98jh+V84LwQ6gBn85vhk4N2S6Uj20G5LxqOGm/lo2dMpWKIvgoTOiBjJSSP0nivHR1HcckDRK9WUOTbKkjSYbeEZtyVsFvynMijhGiV0LV6njHFHEu6JXvMs+Q3aqcYrNH3tfC2com69EfzRMv1YxufDFvxmkVJAqqEVMOW4F2Nx4v5zIU7aszkrlt9swfx4zMk6d3LFxz6Hjkcpss5Acq49hyZ4RNfWPu9pUPSlX9chzzACu1wC7lWmLRToij26BFrxBdOCaXFSz5og/BqRUk+cRxexOiXPVsSh5zIo4RRv9RHTzum1l904KviJa2aPeZZ850Zi/q6PVc6KGTZOOsR9WI/447YPA5t8WMc+i3trqK0pqK2EpgZ7/1rDi3trXRacUrjpfgUK3jX8LtK5ALyyUh9zg8Qn1Gc4Xsevb+XlOXlOuQBZv5uU9zac6vacxjX8XZvbOeU2miVULzeQlKK4fa4E8l2S/JRPrzEj/m5Zk8bLaFi1v637DHHHn181uaJTgkz/ZnC5OuhWFGXfimPXrvHob0mXldR6k3urv1mdkeXyHHmd4lUePTiVqLn5UUp20W57322+eQTcTYndEb58FQY1u6WFBs9sCefWkGcea7UE3PUh/lElM5oUfqBH/iBXe2louBHabckn5gPfeePtOHrQh7zcB0VppkDfXBGo8ZBF6z5aqx314dexJb+6HjUj/2WXndR2qqqthIaGffnOKVdR03PL/41v0uMlW7PKScfu9NdUuczJdaDT0WcGxHx68XIp9/iy49XrTiM6MiX+BEzndpOSf4qTOhk/BnbiJ58/aV48EcLkgqMa6ED7r/+dXaUdkvkUdNbdM9Uc4Nr1YpS7dZXrnxjvdE/rh/5gTVua4zc5YeesPZLwj3zQBdc9PfvlceRvbYr03jrIEaG4sZ4sd9dlFqJ3PW4ipAXpUsUGO1Ser7E4EWkZx2UK/nGnZBrxbEe7VU+A8+UiKNPQfGTEH18ehFexBH+FrulGD/2S/m0ChM6Jf6ofUZPHHjgTFFSrmihA5b+D8W13VJNb9EdXCDx1l5gs5DS3f93to6zeXqMG+2bH0T0QPeL7ZHdEnoHTObRU+Ri/FJfMfwlv5P4Sb/6e0qlQNdg94s6F3LdRuvdWcAvzcWLkYqftImTcXpjK65+B0pHvHUnDfJSQeqdS5bPlC35hNvS4VOOTjS1OeFavDiuLwPAd4x+tf6Bt78iarfElwtq/tmYNHT4fMgn8x+xbaVDzBm9OL/4vKtVOFR419yO1M6F22Y812E3Q26an68/8x1F6bnmKL/kL03PL/ZLPNlVJJl/5ke+UZ9bkSWu/s+0WsdWES7pe7wsr1nbEq/y+1Nx/R5sUdIi6QKuCzfFQth7Iefiny22FyTG0SUWdrCmh4/Q+b4T8qKnYkU85168PbFTUk46oR0PnYl/og79Ial9Kq0dS68e8cEWr3Wx7tVpxWF8Vg+ecHSXpDm25kl+Paj4/v9jEsfz69Go+ZQu4jVOzxgXUvluma/Hjrr6xdXafLRbete73uUSxfZd5O/B9x8Plm6cV+wfbt9RzRbWlTf4ggOFIF7ce9IvPYPKChJ6KhQazw7p/czP/Ew2tNh8J+S7pFiQSjEWoUs1bs8bzgewFU5+8SVOLx9915jhw5HOmi88oKOLb/Z7Rtm8Whdq5bPF/FgrcszQfbI2eZQKEvOL45nWWpsusvFCS36OikNe3F7av82rjrhDQ79X1POLbWmgB/bqwo2a5FvS0bq88MILpeEze9Snf+ZoBsXQrqz1MspJkxglVO067JSoVCfsB9RhV6FdCDsRbKVpUNB8XMVNxaJ2aFxFg1tw7qvCpAKTxfbCIw6F1O1ou+adtm93SpwPYE8OmW9ma2k5x9stno+Lp98dmr2FhxZ/Skh6uiVIPiB+Qv2vMkqHdm4ZJ7OVNDI7/IiZb2aLRYdbd+jF8UxjC5vilHZLrq+89Au8/BKv/rQQf5fP/Wi7LzZH5hnRfbJ2LKLw3VcFBDvo4yNt52snVCs8Khr6KzTaVfXcziMPj4EtQ+nr1XO0/jftpZg3t+/0ieP2gtQT7Fp8fLejQqC+io0KU1YYyDsrSPobdzUOXCHF493vfvcu/uVwxda4XjpUdHRQLNWm+HlBkq03vjQucthOSSeMPs2UTpwYX7469o81z/72VvSt9Red2/g139KYND718qcOu6XZwuRFRrslvVSY4i/Kaock39pOSUUpzmt0fbO5SnNWJ3uWhB6xYqHAvgWqEHFxZ7fkOwHWi1jMk4IkO23xnCs9jaGPRkQVYXQdo5/3ydVtWVv56Bd4pbv28LX4zKdvvubemhs7GcWOz5koKipwjJ3E2D/3wmc29x6+xySO1uumKK1fNzTvBHXB10U+FhftYHizdMEvXeTjH3FV0vqbeSOHctD/+I14zmUXJZ+YI8XHC5Lypoi5zp23V+yUlCs/gCpM3j909v/oFlZPkVh0Gj/QtUKge9hb7JbIXaji48XKx2ptvqYe50W/xq2NwQdrvnEs7oK4QLvfzLO53lwU78UXX1zCZbslDbqetyFSmOj3or5ijV7EXo2WH7otv95x9PRhWM+PVHh6jlKB0LWLotSjM+JTilnTYH7PqVpRscAa8RrG/ALOToS8eB6johXH5KMiEf80kHZJrolWDxIv880KkuKoaLGjupqCpAnsNzvZ+XC7CcqmeGKDy3kU8cS50nEdNCruxSH+enjRoTIwU3wyOd9Z+bzky9wiZjrR5lqj/NIuyTU9vxi71ncNb0e9bHeTfcBzjdkClOWroujanp/sWxwl/Vlt19Nty9rvLs3GuE8e83ue6qRkvH2fyfXE1sVdF31d3H1HJLsu9Fz4peXjsVBoPP6QytZ7KJ52P8qjdshHh/IiR+FVHfsNjp8DtBsblrMpHHmnO6aeXRJiUQP7KG69WxqJr9jskuAxL/VpR8S3hfDwi33sEeMuSTuikfcm6s32VZi8EJV2S9LvnVtPLvz5oahJf6vdA3rkFPvYZ1BaemYj7N0xzcS5D87h9p0q1GHB9AHh9hbOfSQzElPfwKPAxFt1XPRVKNiRyEYRi3Fa/wuL6B/7FL1YmJSj4mqcW3pXtTOKE7ndKcms82E5L6Jfow8vYoN2MizuFkftr4dvoV/SyAqSfJmXry/rVNIq2dHSuOuV/GXPPoC9//3vr1HubEwFSi9/PkRwnyu2GVRBQt81ff3cPhMDjuugz9haRJsve2gXeU3FaU1hP3wlXAt2OB5IQVKuFAK1YzGQjcIkVEEoFST5UtzUnj08HzQUm/jaKV11QbpNWucC5wPIfEYRPjj6NW14pbi9zzzibqWk5/YZjvjKSf9Lix4+8wM9fm9bXPhgjRt3STXf+xir5adbbrVv29XyVSH6wR/8waUgZb6sH5j59Nq4KEsLPbBXo9dPurqVp/+5aesbbz2a5N7jW/JZo/HsjW984+EjqSam6usYA/7d3/3d7rnnrucvE/mXBfgCQcxZfffLxmXbomBkcfhUVop7TfZPfuKTu1962y+lKdXOi5QQjOLriwkf/OAH098h+qM/+qPUrttKv/mbv3lQi0VN/Z6Lv8i/8Ru/sdyich0VEG3K9umlh+Irb71Kt7ikp/kpl95CGYP5+vJzqF1NtrPRLkyv2uF6elaoOyDSql30a3p3OaZv/bV+bpgHu6ssP2n4K/PJbNJc+/xKRSKbg7Tf9773pWPirLmY+1z0/mvnxHmguDqvPvvZzx7clFsr1siXFfTlJn25iHiKw3kc0fPM2s/e9KY3dd8nueaipMmVClNWLLLFKPEzX7ex09KOjTbjWxQ7tC6NXpR0cq09ttBQDlvobKHBekiLb/7NFqGt5uU50S4hOZfGsW+5VmiOYnZBd40sR114dbS4rhPbmW70me1fUpuc7iLGpWOlOyWCRry2oqT8YsFRYeG2WTbOnFQsSrf0xOevRqgdD/H4HSkvQvLVN/n8f6E+W+hizLvoe1Eink7y0U86cB1dx+29bec/5dNeNV+vtnfNQx9Ojp+Apbvm8Lx4H9fowXVdbGvQ9cgTXKML96HrMw+wNp9l3W537HBK+GC/fceE9CzHnymprZcKhBcM/IW696pxCo7zNS4e3DimcT+kQSGUXUXysRw60XREHJkfXNcZ4bsvWhHdp9WGKz9vt3jZOPyImW/Ntpbv2mjJ5m336W0f+afnQS8/+qEXMfqN9NESx9sjGiVf9CKW/HvtUS/2e3VaflGXfos3O45+CXu/RPe8qpgfEqSygT5+jW3tevh2G/lRVOiDvnOBw66JvwiBb4YqQnyrjqLmfrK1Cpn7X3Pbz43Z88I1NNcnnfN3PK5RXKdzRtkSteK9fi4YZYXjSNTSyOz7J26qF55FjORX0pR9TZ6ZbraOms9ovpl2Kd9Z/VIM2Tmy9bmWeIevhMeFpQ8ykWtFFQIVFhWDnmLEPMTRzkbFSRoqWLLpiDpZAUKnhrO8muZdjvk5QBvszSP60wcfqo7y9jnQBnvnFXXgzehkWrqgZnbitDDmQR9s8eN45K3NT/pR023ZWMyp1HduzNPHSvyW3TVoR2xptMbRi37YI0a/mT6azsUW0X3UPvk9JSolGJ2vua+Lv14qJnpp1+PPhUrFQbf/NKaC5sWp5N9ag8eyS2KeOhd06ESaPS/glZBYLSSXa8lHeZDTmvUp6bBeGh854JVwREu+JR3s961Hjp7H2vcDLc1Rh+sxbxDfGby0vnIihud3qfkQI8YciXcoSgiJqAPE/pBQxWS0oMBRMVNhYpcku3ZPOno0teuCC6eHdwhwxf9wPoAzqfoPMDrgqB48cJQv/2vLx+fAvEAf621vOT/FvHY91sXXzNuMz+LW88/yIN+Ime+sDW3xaUec1W7xYhz6kbcUJS26HyLwRoA+/hjbKiD6Oinf6FOBoch4ceGZEmOlZ1EUtIe+VvHc0Hz8/Oidn+s4n/MLbOm5Dr6uh62Fpzr6QHb6LbOt8unVUb6nOR1nsH5+N1quM5JXKbet9Zix62LrwZ71Y95gj658StoaO8lXl9Kbz/ca6jpq2hJwffIGuwLcOq2KMzEvchuJu3wlXGRNvHZc41fCa/muHVPRqT2nqunr2ZQXsprvtYxlXwknt9a5gV8Ln3RaK9T+OWwrnHpsteZS3VKLLB+K5iXzRVt4ifVwfdp3FYd4jrXYy05JBK9mIs1UYg/80NsqKnqxYyrtiHye/u0+tz/0tp8bmsvs+YGO82fOM3RYV9fD1oPoOP8+81HO5KT22rzQ2+rbY+SW5TWzbuQn1JHp3oyM/UuesDLdLfLN9LHNYsxdOlvmT14ep3Z+zK4TcTL02Br3+Z0UJQYRkePTcfM8yXc93LYDtUYUsMe+Xn5OeHtk3vAijmjIFz682MfeQngRW7xsHA2NeTvzbdngR2zx0vH9j/LW3x6LedFP43cY4UfsoFZdol7sV8mVQXRwiX3sa9A1aUdcow+XPxGkftSnj++lkDhnRalWwS6VzEPTpUCBDy3/Nfkezw99YLnMM5je/I65iHHBfAbupZ/mdJyJfuA0xg/ecaTcOtWan58inGrdXHjIJ2I5o+PI1npZjrJln+CPWfS1Yq4HXXs/ZuYvjUyXjPz9Rp+xESzFyPTXxFFOpVgau0Q86XJ47LOiJKf4gxP7CD3hK3MFjueDLpTH8+Vo71uX6B/7fSrH+PvWgYIOOK5zw1j4N7K9Mic5OGnRc2NH+8hbNz+FOmod29jAjpQWF+fQjrg4dzbg4x53eNhH8Uz39k4QdnBUV/4ZFxs4o+ucqEM/onNm22g6H1tE99minf7Jb6pWxC0CPmk8/BWI5wX90ZmJx0vcNTrOX6OzRT6sA3lEZLwXIz/2e3XkJ27k0x/RwbemN6sLr4TEHkVy3VpXebj2JfRjDPoZyrb26JkP81wbK/LTnRJOl66IxHnCh7kCW5wfaGgFvD2zIvDBNRpr89EPLHlEnMnL87mU3mxe8GJe9BkfwUusH/HJKyLjaxBNadAG1+g6F70Suu8W7VIc7FvEcI1iUYpV8FIJeDJP7ftdAT3s7D2y84MLCXiQa9z6ijrE1/m26GCsYNRx/hodQroethbGnOTvOmvyynQek57WKls/2XX4/G8s/f9muq7HOoL9yuWct9JXLln+MceHHK9YlDRJTezpeOWsAPfue2cczw/64O0jnqbc4h88S/bgtnSjP31wcexoZJzM1iF19nOEDtijgY9zaEfEtwfhypd2xB4dfOBupec6xAA9FrYRjHz6EUc03RcdbPQjMj6DaGVcxiJmviM29CIHe8To1+qnz5QgqSLzwvaEj3cFRnZKWgXODT65gaMrVNIZ1dtKJ86NPMCZ+aGZ4Ygec8x09j+uw0ddb1xwaz3mWdMdnvQtAU0hcTK8dR+GS+uTq8fRVErzGbgRUp3rabzyM0ryqIolg9Wdkvypegn3yfTIVmB0p8T0OUdA7KMIP+J96xCfvOiPIvyIozr4R53ZGxvnOqff8iPeKJZ0R3Xw31oPXfCx6O+v2ocpxfn03rlgPXoxxon9Xh38mkVpttoR4AkfzgqwU9J7rhMLbM0gO0dG+Oi7jvN788h0sLkethZ6Pvi6zkheUSvT0afc3sLSo9fzTE/zilqyZfnJ3ntEzUxPPrL3HlHTea7v9t521HY98gR7Nd3v0vqKFWN4/K3n49pZXH6/DL+R+M2iJFEJPh2PfwXYKfF+gz0zz3wzW0vLObTBFtfHM05mc06pHXn0wRIvszuH9hEzRtkGDw/64Ogn44V3K0gfJM4IOpd2xBE9+cKPvJI9+tX6rkE7Yo3fGkNLfrQjtjR6xtF0X2wR3WdtG23pcD1Bk7GIjIPVZ0o4ZZWQsSd8PCvATmlmRjpHOE8ijuhtrpPcYx/JR75xPrE/orfV/Mgr0xvJx33RivOj7769bTTlj07EXi380Iw69PGbQbTFRS/ijC6cS+vHOHcVL8ZVn9hx/WIfLti1U8L5CR/3CsRPNqOzjZ+A6N+XziHufpPPvGbzIX/4ERnvxcin38uPfvDBOD7aRyfiqE70j3r0o99oHx1wlF/yRy9iyX/Ergtz1KU/ojPii37EEY1eXwoPscSjHTFqdhclgkSBp/7jWQHtlHifdeLwgwO2ZgrX/e5TR3lkOcnueanfOqKO81kfcFRL/neh18qL8TjXtfmJHzXXzJc8M13GMv3eZ2w13ao+g50Y18RpWf6955fr0K7Fks/W8Xrj4ufxu4uSyP/zP/+ze/WrX43OEz6yFfjiF7+4fJrR1HSiOB46Hf/Aw5U+iL2F0Z8+2OIzXvIv2eFl6BzaETNeZoPHGP2IjLcQHn70Qey9GHn0I/bqyQ+ut7GBI3r4Zlxs4Ogztpp2lj/+M7jkaGRsEc1lqoleJGOPGP3W9NHONBjreqaEwH/8x3/QfMJHuAL/+Z//efhEy6cqcHSq8ErYqyc+L3HQ6+Xjhwb8iPj1IFryXaMDP9Ob/X0StGJe9Hvm5z5NvZtf73FKs42mHMkrYlMkcUAXzPQTWpcJzRs8z3v2/fLgpzFuFlY2HRGdN9OOsaJ+7M/EKHGy2DHeUFH6xCc+UYr1ZH8EK/Dyyy8fPsnyiQWcnRr8iCN64q7he6yoQ999etrwIvZwM58znRVfdpVW1KOfxe6xwY84u/MgZtSjz/gMSgOdiDN6zrnRPu720F+7Dh5DbXRLGP3X9G/mdHpHJMZdo9/iZvEPRYlK1RL467/+65bL0/gDXYHPfe5zu3/4h384fCrzTzOaDucH2DNF14AX8S51mAd50c+wlRcajjM6xHEd2q6HXw/CjzirB6+mp7HRo0dvC13iMI8Me3NHK8NMdyZ/dGIM7BnKNnvEOPSlR/4tnI1NDGKCh6JEZWyJ/+u//uvuox/9aMvtafwBrsCHPvShJWs+vXBeRFwcG42tdBQGLdqOavceNR3mOaoFL2KvjvzIC8Q2ouG+6IBr9eBnerLNHjW9LXQfqn7Peq9Zn9L71bNexAVLWrP2odt3CvJbv/Vbu3/7t3+bjffEu8IVeOmll3Z/+Zd/uWS21ScjPvlEvSXQQAMtUdbobaVDHpnewLQWV3RA9BeHwQY64Fo9+Kne+EZpmU2mJxvxFsfBBrrgid6KfEkDXdD1ZfM+nFFEO+rF/qhuzZ+Y8olx6PMMbenXBCfGhovS//7v/+7e8Y53PBWmicW+Rsrf/M3f7F588cWz1HTC8Uko4plzw7CWj3zUoc/4KMIHR/n4wwexz6A00AFndOBsrSdd8gK3eqaCXkTmMotnevMbuzSFqB/7KWnCGHXpT0g1KdWf/9v1u1T8L3vd6173K8pQATyRWtZf+MIXdn/1V3+1+8qv/MrdN3zDN9Rcn8audAW+9KUv7X7v935v99u//dudGepMPP2beL3nSxZg5HzL+NhcZ6t80AGJNYJb5UVM18O2Bl1vzTzJIdPbQjfTx7YG7zJf1gFck3eJe+n5xLjEw04/Q3x68dkb3/jG6c2sEvj6r//63Vve8pbdt3/7t+9e//rX7171qlf1xn7yu+MV0IcJ3Xr9+Mc/fvhQ8fnPf76Zgd7jLY5r09Gctsppa62HoHeJHC+lKV0dW77fN4qn/15a36PdZSzi3lXMZ9/93d99KEoKuKaSXxN/mYdmNnhN9XksOrwrA+g6A7TF1flr8kDQ9bCNoPOvNZ81efn8Rtal5PtK1uN9AEtrVLP7+qED1ni9Yw9dP87z0vMpxbu5wOZ3UGbfr+c1GQ5vY2uhc7zd4vk4PNDHRtrwwZmCpHjwwZkcXGeE777EB32spx15sd+jIR94EXv57oeG6/r4SButiCMangc6o3z3dw1vu89I2zW8PaLhvq7hbfcZbaNTwlE9+fsFLerO6GWcqEs/852xoRdxRqvGifqxX+POjvn7wyf/GJf+aIznJa5DAgQCe8Tg4zujEzViPmjXMGp4HjWej7mG82VXv0WBrDsAAAaHSURBVOdwDfnvH1vvn8ScfpKY0rH3p4cvn5iLbDPzaulIt/eIWjP5KNZWOpmWbJ6X+r1HzAveVnquo1jqjxxb56fYmebaPC+pm2ln+c6sr7R1ZGsi+9ZxSrF64qyZXymu7Dpq8YkL3jCO/6Y7JQmOHNGfPtijlflmtppW9I/9Gpcx59AG8Wlh9Fdh0hHtwzqD7wv6MS59EL8WRv/Yb/EZjzz6IH4tjP70wRbfxzNOZnNOrZ1xM1tNg7HIow/iN4IZN7Ot0UQPHNFy38inD7rvaNs1aEcc1Yz+6GGnH5HxNYimNGhHRB87/bUY9ei3MMZ9TtVKLx1gdGr14UVs8Xxc3Min7361NhrwwBonjqEh+wzfefAjxpilPrnM8tGNfPqM9+Kl87k9DXvTObw/5CTS7Lzgwo/YnZA5Znmha25dTbTgR+wSCU5oyryFHjqX0kU/Q9lmj1q+rMusNjxioBcRvy2QWNKKcegvcW4u+0t3bYPYxOnFGPfwV8JjJYtOvf21OpFPvze+/Jzj7RmNWb5i6Q2BH3EmF3HQGeG7L3zQx3rbzvV2L9/94B/RR/vbR/7YDr8UYSu9qEO/FLdlhx+xxWuNX1oP/VYetfGtfp5KMS6t73FZD9DHtmp3zWebH5c05Vp85g1GgUNRkkA8RHDhOB77UcP5vTqukfF7dFzDc3Q9t2ftTGOEj6brOJ95gPhn6Bo+7npuL7WjjvN78kA36mB3PWw1jDrOJx+wpqOxqCVbpid768i0xHG9lgbjJa1r0VMepRx9vvJRv/fINDO9LXTJ6SHoK9dsbWTfIn/p+FGKJZ9qPJWD/ds9+v54bLVr8aOv57P8/5RkjEdmiz7ej/70Qfcttd2XdsQSFzv+9MGSnXHHzDezOSdrO4d2xIwXbXDcntl8PLajP30w+pf6Jf+SvaQju3NoR6zxfQweNvog9h7MOJltVku8a9Er5UJ+YM9c3Sfy6Ed0Tk8bfvTFHjH6tfrwox/2iNGvt48O/vQjMr4W0UWHfsTbR+DT5yf6EYkT7fQZX/7MkKoalS0ipBaiMcuXPhq0HdXuOWL82O/VIJcZPjHQUP++dcgl5pFslEk/xbLO+Y47FTAjWjLFvMytq4nWWh1y2UqvpEOeXZMzp631tp4vqbby3GL+xGAOxF6DaDq6/vLzMn66n6RV1r8R1viWx2i8S8bX1Er5LDslTZ5KFXFkYeC63gjfeWiB96Hjsb09kgu8iCMal12X0Uxu/ON86I+qwYs4qiN/NGJ7rdaWeuQIzuTm+aADzuq5ZmxvoUl+EbfQ3jJfz4dcXX+5qXR+c8mpw21iRRwW6iTEOPShxz72bfCm4HoM2idFySujHNR37EnGNeTvfPRaOlEj6rT4Go8ansfhr9x2nlA1nbucT5yTz6c3D9Ytzkl218Ovha7jfPIBR3Twdb0171eqh7GBPj9cPa/e+cF1vUxnjR4xMl3GetBzdH/XdXtPO9N0PeYN9mjik2lrLNMfOY9m9Gfyb8VhPJvPQ4rHPCJm799JURJBk+egDWJvYfSnD7b4Gs98M1tNK/ov/eMUa/RlbOHdWuiDi2OlkflmtorEYcg5tMEW18czTmZzTtZ2Du2IGS+zwWNs6Q++X+IvXMQKNhsuNqMWfbBILAzAK2GBVjSjgwN9EPsIZtzMtkYTvYgjmviiQV+IDeRZifv0thcNI2CLaC5TTfQiGXvE6DfTR9O52CK6z9ZtxVqeKSGuykX1AhnrRXgRe/nyEzfy6ffqoAEP7OXjBy8i4z0obuTT7+Hj81h1ND/mxrqAzH0Ib+9Zo+s4pLN3Jo8SPjY91mqr+bI+0uNFjAzxH0F0wa10yQFdMNPX2BYHOgdMzmNibBTuIMe8QBlP8rD+gXChfxTzbKekWFtVxrU6kU9/dD3ggaN8/OGD2EcRPriWf9865E8eIPYRdK63RzTku7/8nZ3Hq/T2PyzwI47mhn/Uoc/4COqHGX7EEZ3Md2s9YkRd+ozPIjoRZ/UiL+rGfvSf6VMQtLsr/UUYu6k1E6LJifOi3ySudEiL0rIgJq6E/MS3obQZNZzfqxM1FOgSOukEgjHmMpOHJKMOYVwPWwkzDefrE1TPCdvWOV7oSrlgj1qn+czroO962FoYc5K/62hc/d7jVE+8Gz46YI/eqdaRsV1+R021XPd0pN67RJ6KeCndkrbPn/cJrK/A+Wgpd3luGUd6pVg9cXqvA4oTj1Jc/Prij/18of3/yO1bWUqCHykAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - inference.redhat.com
+          resources:
+          - instaslices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - inference.redhat.com
+          resources:
+          - instaslices/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - inference.redhat.com
+          resources:
+          - instaslices/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - instaslice-operator-scc
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        serviceAccountName: instaslice-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: instaslice-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: instaslice-operator
+          control-plane: controller-manager
+        name: instaslice-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: EMULATOR_MODE
+                  value: "false"
+                - name: RELATED_IMAGE_INSTASLICE_DAEMONSET
+                  value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9:0.1.0
+                image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9:0.1.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: instaslice-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  secretName: webhook-server-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: instaslice-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - GPU Slicing
+  - MIG
+  links:
+  - name: Instaslice Operator
+    url: https://github.com/openshift/instaslice-operator
+  maintainers:
+  - email: amalvank@redhat.com
+    name: Abhishek Malvankar
+  - email: mmunirab@redhat.com
+    name: Mohammed Abdi
+  maturity: alpha
+  minKubeVersion: 1.16.0
+  provider:
+    name: Codeflare
+    url: https://github.com/openshift/instaslice-operator
+  relatedImages:
+  - image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9:0.1.0
+    name: instaslice-daemonset
+  version: 0.1.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: instaslice-operator-controller-manager
+    failurePolicy: Ignore
+    generateName: instaslice.redhat.com
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      resources:
+      - pods
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-v1-pod

--- a/bundle-ocp/metadata/annotations.yaml
+++ b/bundle-ocp/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: instaslice-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle-ocp/tests/scorecard/config.yaml
+++ b/bundle-ocp/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.34.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.34.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.34.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.34.1
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.34.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.34.1
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/amalvank/instaslicev2-controller
-  newTag: test-e2e
+  newName: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9
+  newTag: 0.0.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,7 +57,7 @@ spec:
       #             values:
       #               - linux
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
@@ -74,7 +74,7 @@ spec:
         #imagePullPolicy: Always
         name: manager
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - "ALL"

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- instaslice-operator-scc.yaml
+- openshift_cluster_role.yaml
+- openshift_scc_cluster_role_binding.yaml

--- a/docs/downstream-builds.yaml
+++ b/docs/downstream-builds.yaml
@@ -1,0 +1,23 @@
+If something changes with how the operator is built, Dockerfile.ocp may also needs to be updated.
+
+Modify Dockerfile.ocp
+
+Make sure the image builds with
+docker build -f Dockerfile.ocp
+
+
+If something changes that affects the bundle, the ocp bundle needs to be regenerated.
+
+Update the version is necessary
+export VERSION=0.1.0
+
+Set the image urls for the offical repos
+export IMG=registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9:$VERSION
+export IMG_DMST=registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9:$VERSION
+
+Regenerate the bundle
+make bundle-ocp
+
+Konflux CI with build the images to catch errors.  In the future, Konflux integration tests will test images for PRs as a set to verify images urls are correct.
+
+


### PR DESCRIPTION
This PR adds the files necessary for downstream builds without limiting the ability to make upstream builds and releases.  I had to add one additional make target to make this easier to manage.  I also added some of the necessary downstream changes necessary for productization.

operator runs as nonroot now
Added kustomizationfiles so that daemonset can run root

How to test:

oc new-project instaslice-system

operator-sdk run bundle quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-bundle@sha256:4f442009b6b986d2a9b94969be5dd3e93e7821c307fe811b888ca3037f2a7b2f --namespace instaslice-system
(bundle use sha that matches op-pr-<commit> tag)

update CSV to point operator image and daemonset image to konflux build images, i.e.:
quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/dynamicacceleratorslicer/instaslice-operator@sha256:381462c114dd3b07b42413d99db351a37e702654d73341e51dd30935e32f16f4
and
quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset@sha256:2f0e7ca4bb16763c49dc6544e412f3cfb4df2762a01c40229080acc5d86d0d55

Also update EMULATOR_MODE: true in CSV

oc apply -f config/rbac/instaslice-operator-scc.yaml (FIXME)

oc label node/<node>  nvidia.com/mig.capable=true

oc apply -f test/e2e/resources/instaslice-fake-capacity.yaml (edit name to match node hostname)

