### PR TITLE
Fix the daemonset crashing

### DIFF
--- a/internal/controller/instaslice_daemonset.go
+++ b/internal/controller/instaslice_daemonset.go
@@ -423,8 +423,14 @@ func calculateTotalMemoryGB(gpuInfoList map[string]string) int {
 func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() ([]string, error) {
 	log := logr.FromContext(context.TODO())
 	instaslice, _, gpuModelMap, failed, errorDiscoveringProfiles := r.discoverAvailableProfilesOnGpus()
-	if failed {
+	if failed || errorDiscoveringProfiles != nil {
 		return nil, errorDiscoveringProfiles
+	}
+	if instaslice == nil {
+		// No MIG placements found while discovering profiles on GPUs
+		//Hence, returning an error without creating an Instaslice object
+		err := fmt.Errorf("unable to get instaslice object")
+		return nil, err
 	}
 
 	totalMemoryGB := calculateTotalMemoryGB(gpuModelMap)


### PR DESCRIPTION
I observed the following logs when tried to run the e2e tests without emulator mode.
Added a fix to resolve the panic.
```
{"level":"info","ts":"2024-10-30T14:55:25.124049928Z","caller":"controller/instaslice_daemonset.go:437","msg":"classical resources obtained are ","cpu":16,"memory":65971478528}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x130 pc=0x19625f2]

goroutine 38 [running]:
github.com/openshift/instaslice-operator/internal/controller.(*InstaSliceDaemonsetReconciler).discoverMigEnabledGpuWithSlices(0xc00067a000)
	/workspace/internal/controller/instaslice_daemonset.go:444 +0x232
github.com/openshift/instaslice-operator/internal/controller.(*InstaSliceDaemonsetReconciler).SetupWithManager.func1({0x210e2d0, 0xc000159590})
	/workspace/internal/controller/instaslice_daemonset.go:361 +0x1d3
sigs.k8s.io/controller-runtime/pkg/manager.RunnableFunc.Start(0x210e2d0?, {0x210e2d0?, 0xc000159590?})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/manager.go:307 +0x26
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc000631760)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:226 +0xc8
created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 89
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/manager/runnable_group.go:210 +0x19d
```

/cc @asm582 