### PR TITLE
use pinned images

### DIFF
--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Drivers and plugins
-    containerImage: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9:0.1.0
+    containerImage: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9@sha256:0d8fcbe0a52b59cea9f699a4bccea9e4c148a457447a76602a68eabda2d17184
     createdAt: "2024-11-01T14:26:33Z"
     description: InstaSlice works with GPU operator to create mig slices on demand
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
@@ -37,7 +37,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    repository: https://github.com/openshift/instaslice-operator
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'repository: https://github.com/openshift/instaslice-operator
     support: https://github.com/openshift/instaslice-operator/issues
   name: instaslice-operator.v0.1.0
   namespace: placeholder
@@ -212,8 +212,8 @@ spec:
                 - name: EMULATOR_MODE
                   value: "false"
                 - name: RELATED_IMAGE_INSTASLICE_DAEMONSET
-                  value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9:0.1.0
-                image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9:0.1.0
+                  value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:410768da8e0efb82960d3132f7ab4378736c071d7d25d3877f863a50002adc0b
+                image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-rhel9@sha256:0d8fcbe0a52b59cea9f699a4bccea9e4c148a457447a76602a68eabda2d17184
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -339,7 +339,7 @@ spec:
     name: Codeflare
     url: https://github.com/openshift/instaslice-operator
   relatedImages:
-  - image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9:0.1.0
+  - image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:410768da8e0efb82960d3132f7ab4378736c071d7d25d3877f863a50002adc0b
     name: instaslice-daemonset
   version: 0.1.0
   webhookdefinitions:


### PR DESCRIPTION
Image urls need to be pinned with shas.  This will allow konflux to update the shas as new images are built.

I also added an annotation to the ocp bundle to define the subscriptions. 