### PR TITLE
limit which files trigger pipeline runs for which images

### DIFF
--- a/.tekton/instaslice-daemonset-pull-request.yaml
+++ b/.tekton/instaslice-daemonset-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-daemonset-push.yaml
+++ b/.tekton/instaslice-daemonset-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-bundle-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && files.all.exists(path, path.matches('bundle*|tests/*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-bundle-push.yaml
+++ b/.tekton/instaslice-operator-bundle-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && files.all.exists(path, path.matches('bundle*|tests/*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-pull-request.yaml
+++ b/.tekton/instaslice-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-push.yaml
+++ b/.tekton/instaslice-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer


### PR DESCRIPTION
Make files that trigger konflux pipeline runs mutually exclusive between bundle and other images.  This is based on the recommendation from https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#_building_bundle_images.  Changes are based on the trustee operator as  a starting point.  We may want to tweak the patterns.