### PR TITLE
Move daemonset code in a separate package

### DIFF
--- a/Dockerfile.daemonset
+++ b/Dockerfile.daemonset
@@ -31,7 +31,7 @@ RUN go mod download
 # Copy the go source
 COPY cmd/daemonset/main.go cmd/daemonset/main.go
 COPY api/ api/
-COPY internal/controller/instaslice_daemonset.go internal/controller/instaslice_daemonset.go
+COPY internal/controller/daemonset/instaslice_daemonset.go internal/controller/daemonset/instaslice_daemonset.go
 COPY internal/controller/constants.go internal/controller/constants.go
 COPY internal/controller/utils.go internal/controller/utils.go
 

--- a/cmd/daemonset/OWNERS
+++ b/cmd/daemonset/OWNERS
@@ -1,0 +1,7 @@
+# Only people with access to suitable GPUs and willing to test changes should be on this list.
+approvers:
+- harche
+- asm582
+
+options:
+  no_parent_owners: true

--- a/cmd/daemonset/main.go
+++ b/cmd/daemonset/main.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
-	"github.com/openshift/instaslice-operator/internal/controller"
+	"github.com/openshift/instaslice-operator/internal/controller/daemonset"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -133,7 +133,7 @@ func main() {
 	// 	os.Exit(1)
 	// }
 
-	if err = (&controller.InstaSliceDaemonsetReconciler{
+	if err = (&daemonset.InstaSliceDaemonsetReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -19,14 +19,14 @@ package controller
 import "time"
 
 const (
-	orgInstaslicePrefix              = "instaslice.redhat.com/"
-	gateName                         = orgInstaslicePrefix + "accelerator"
+	OrgInstaslicePrefix              = "instaslice.redhat.com/"
+	gateName                         = OrgInstaslicePrefix + "accelerator"
 	finalizerName                    = gateName
-	quotaResourceName                = orgInstaslicePrefix + "accelerator-memory-quota"
-	emulatorModeFalse                = "false"
-	emulatorModeTrue                 = "true"
+	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
+	EmulatorModeFalse                = "false"
+	EmulatorModeTrue                 = "true"
 	AttributeMediaExtensions         = "me"
-	instaSliceOperatorNamespace      = "instaslice-system"
+	InstaSliceOperatorNamespace      = "instaslice-system"
 	NvidiaMIGPrefix                  = "nvidia.com/mig-"
 	NodeLabel                        = "kubernetes.io/hostname"
 	multipleContainersUnsupportedErr = "multiple containers per pod not supported"
@@ -36,7 +36,7 @@ const (
 	daemonSetName                    = "daemonset"
 	serviceAccountName               = "instaslice-operator-controller-manager"
 
-	requeue1sDelay  = 1 * time.Second
-	requeue2sDelay  = 2 * time.Second
+	Requeue1sDelay  = 1 * time.Second
+	Requeue2sDelay  = 2 * time.Second
 	requeue10sDelay = 10 * time.Second
 )

--- a/internal/controller/daemonset/OWNERS
+++ b/internal/controller/daemonset/OWNERS
@@ -1,0 +1,7 @@
+# Only people with access to suitable GPUs and willing to test changes should be on this list.
+approvers:
+- harche
+- asm582
+
+options:
+  no_parent_owners: true

--- a/internal/controller/daemonset/instaslice_daemonset_test.go
+++ b/internal/controller/daemonset/instaslice_daemonset_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package daemonset
 
 import (
 	"context"

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -81,11 +81,11 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// 1. Ensure DaemonSet is deployed
 	daemonSet := &appsv1.DaemonSet{}
-	err := r.Get(ctx, types.NamespacedName{Name: instasliceDaemonsetName, Namespace: instaSliceOperatorNamespace}, daemonSet)
+	err := r.Get(ctx, types.NamespacedName{Name: instasliceDaemonsetName, Namespace: InstaSliceOperatorNamespace}, daemonSet)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// DaemonSet doesn't exist, so create it
-			daemonSet = createInstaSliceDaemonSet(instaSliceOperatorNamespace)
+			daemonSet = createInstaSliceDaemonSet(InstaSliceOperatorNamespace)
 			err = r.Create(ctx, daemonSet)
 			if err != nil {
 				log.Error(err, "Failed to create DaemonSet")
@@ -104,7 +104,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	listOptions := &client.ListOptions{
 		LabelSelector: labelSelector,
-		Namespace:     instaSliceOperatorNamespace,
+		Namespace:     InstaSliceOperatorNamespace,
 	}
 
 	if err := r.List(ctx, &podList, listOptions); err != nil {
@@ -170,7 +170,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			for _, allocation := range instaslice.Spec.Allocations {
 				if pod.UID == types.UID(allocation.PodUUID) {
 					if allocation.Allocationstatus == inferencev1alpha1.AllocationStatusCreating {
-						return ctrl.Result{RequeueAfter: requeue2sDelay}, nil
+						return ctrl.Result{RequeueAfter: Requeue2sDelay}, nil
 					}
 					if allocation.Allocationstatus == inferencev1alpha1.AllocationStatusCreated || allocation.Allocationstatus == inferencev1alpha1.AllocationStatusUngated {
 						resultDeleting, err := r.setInstasliceAllocationToDeleting(ctx, instaslice.Name, string(pod.UID), allocation)
@@ -187,7 +187,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 							return resultRemove, nil
 						}
 						// requeue for the finalizer to be removed
-						return ctrl.Result{RequeueAfter: requeue2sDelay}, nil
+						return ctrl.Result{RequeueAfter: Requeue2sDelay}, nil
 					}
 					return ctrl.Result{}, nil
 				}
@@ -226,7 +226,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 							return result, nil
 						}
 						// requeue for the finalizer to be removed
-						return ctrl.Result{RequeueAfter: requeue2sDelay}, nil
+						return ctrl.Result{RequeueAfter: Requeue2sDelay}, nil
 					}
 					return ctrl.Result{}, nil
 				}
@@ -256,7 +256,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					var updateInstasliceObject inferencev1alpha1.Instaslice
 					typeNamespacedName := types.NamespacedName{
 						Name:      instaslice.Name,
-						Namespace: instaSliceOperatorNamespace,
+						Namespace: InstaSliceOperatorNamespace,
 					}
 					err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
 					if err != nil {
@@ -312,7 +312,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 							var updateInstasliceObject inferencev1alpha1.Instaslice
 							typeNamespacedName := types.NamespacedName{
 								Name:      instaslice.Name,
-								Namespace: instaSliceOperatorNamespace,
+								Namespace: InstaSliceOperatorNamespace,
 							}
 							err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
 							if err != nil {
@@ -370,7 +370,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					var updateInstasliceObject inferencev1alpha1.Instaslice
 					typeNamespacedName := types.NamespacedName{
 						Name:      instaslice.Name,
-						Namespace: instaSliceOperatorNamespace,
+						Namespace: InstaSliceOperatorNamespace,
 					}
 					errRetrievingInstaSlice := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
 					if errRetrievingInstaSlice != nil {
@@ -418,7 +418,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					var updateInstasliceObject inferencev1alpha1.Instaslice
 					typeNamespacedName := types.NamespacedName{
 						Name:      instaslice.Name,
-						Namespace: instaSliceOperatorNamespace,
+						Namespace: InstaSliceOperatorNamespace,
 					}
 					err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
 					if err != nil {
@@ -455,7 +455,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func createInstaSliceDaemonSet(namespace string) *appsv1.DaemonSet {
 	emulatorMode := os.Getenv("EMULATOR_MODE")
 	if emulatorMode == "" {
-		emulatorMode = emulatorModeFalse
+		emulatorMode = EmulatorModeFalse
 	}
 	instasliceDaemonsetImage := os.Getenv("RELATED_IMAGE_INSTASLICE_DAEMONSET")
 	if instasliceDaemonsetImage == "" {
@@ -643,12 +643,12 @@ func (r *InstasliceReconciler) deleteInstasliceAllocation(ctx context.Context, i
 	var updateInstasliceObject inferencev1alpha1.Instaslice
 	typeNamespacedName := types.NamespacedName{
 		Name:      instasliceName,
-		Namespace: instaSliceOperatorNamespace,
+		Namespace: InstaSliceOperatorNamespace,
 	}
 	err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
 	if err != nil {
 		log.Error(err, "error getting latest instaslice object")
-		return ctrl.Result{RequeueAfter: requeue2sDelay}, err
+		return ctrl.Result{RequeueAfter: Requeue2sDelay}, err
 	}
 	delete(updateInstasliceObject.Spec.Allocations, allocation.PodUUID)
 	errUpdatingAllocation := r.Update(ctx, &updateInstasliceObject)
@@ -733,7 +733,7 @@ func (r *InstasliceReconciler) setInstasliceAllocationToDeleting(ctx context.Con
 	var updateInstasliceObject inferencev1alpha1.Instaslice
 	typeNamespacedName := types.NamespacedName{
 		Name:      instasliceName,
-		Namespace: instaSliceOperatorNamespace, // TODO: modify if needed
+		Namespace: InstaSliceOperatorNamespace, // TODO: modify if needed
 	}
 	errRetrievingInstaSlice := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
 	if errRetrievingInstaSlice != nil {

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -78,11 +78,11 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 				},
 			}
 			instaslice.Name = "test-instaslice"
-			instaslice.Namespace = instaSliceOperatorNamespace
+			instaslice.Namespace = InstaSliceOperatorNamespace
 			pod = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
 						finalizerName,
@@ -96,7 +96,7 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 			req = ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "test-pod",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 				},
 			}
 		})
@@ -115,7 +115,7 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 			Expect(result).To(Equal(ctrl.Result{}))
 
 			updatedInstaSlice := &inferencev1alpha1.Instaslice{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: instaSliceOperatorNamespace}, updatedInstaSlice)).To(Succeed())
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: InstaSliceOperatorNamespace}, updatedInstaSlice)).To(Succeed())
 			_, allocationExists := updatedInstaSlice.Spec.Allocations[podUUID]
 			Expect(allocationExists).To(BeFalse())
 		})
@@ -144,7 +144,7 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 			Expect(err).NotTo(HaveOccurred())
 
 			updatedInstaSlice := &inferencev1alpha1.Instaslice{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: instaSliceOperatorNamespace}, updatedInstaSlice)).To(Succeed())
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: InstaSliceOperatorNamespace}, updatedInstaSlice)).To(Succeed())
 
 			Expect(updatedInstaSlice.Spec.Allocations[podUUID].Allocationstatus).To(Equal(inferencev1alpha1.AllocationStatusDeleting))
 
@@ -194,7 +194,7 @@ func TestInstasliceDaemonsetCreation_Reconcile(t *testing.T) {
 			daemonSet = &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instaslice-operator-controller-daemonset",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 				},
 				Spec: appsv1.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{
@@ -215,7 +215,7 @@ func TestInstasliceDaemonsetCreation_Reconcile(t *testing.T) {
 			req = ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "instaslice-operator-controller-daemonset",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 				},
 			}
 		})
@@ -344,11 +344,11 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 				},
 			}
 			instaslice.Name = "test-instaslice"
-			instaslice.Namespace = instaSliceOperatorNamespace
+			instaslice.Namespace = InstaSliceOperatorNamespace
 			pod = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
 						finalizerName,
@@ -404,7 +404,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			req = ctrl.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      "test-pod",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 				},
 			}
 		})
@@ -466,7 +466,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			pod = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      failedPodName,
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					// PodUUID has to be same as the one present in the instaslice allocations
 					// to process the allocations
 					UID: types.UID(podUUID),
@@ -486,7 +486,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			Expect(err).NotTo(HaveOccurred())
 			// As the allocations are present in the Instaslice Object, expecting a return from
 			// the reconcile function without removing the Finalizer
-			Expect(result).To(Equal(ctrl.Result{RequeueAfter: requeue2sDelay}))
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: Requeue2sDelay}))
 
 			// Update the podUUID and observe the Finalizer is not present inside the Failed pod
 			// as the corresponding allocation details are not present inside the Instaslice Allocations
@@ -497,7 +497,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 			newPod := &v1.Pod{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: failedPodName, Namespace: instaSliceOperatorNamespace}, newPod)).To(Succeed())
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: failedPodName, Namespace: InstaSliceOperatorNamespace}, newPod)).To(Succeed())
 			Expect(newPod.Finalizers).ToNot(ContainElement(finalizerName))
 
 		})
@@ -509,7 +509,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			pod = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      succeededPodName,
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					// PodUUID has to be same as the one present in the instaslice allocations
 					// to process the allocations
 					UID: types.UID(podUUID),
@@ -540,7 +540,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 			newPod := &v1.Pod{}
-			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: succeededPodName, Namespace: instaSliceOperatorNamespace}, newPod)).To(Succeed())
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: succeededPodName, Namespace: InstaSliceOperatorNamespace}, newPod)).To(Succeed())
 			Expect(newPod.Finalizers).ToNot(ContainElement(finalizerName))
 
 		})
@@ -550,7 +550,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			pod = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod-1",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					// PodUUID has to be same as the one present in the instaslice allocations
 					// to process the allocations
 					UID: types.UID(podUUID),
@@ -581,7 +581,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod-1",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
 						finalizerName,
@@ -630,7 +630,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod-1",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
 						finalizerName,
@@ -686,7 +686,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod-1",
-					Namespace: instaSliceOperatorNamespace,
+					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
 						finalizerName,
@@ -805,7 +805,7 @@ func TestInstasliceReconciler_podMapFunc(t *testing.T) {
 	}
 	instaslice := new(inferencev1alpha1.Instaslice)
 	allocDetails := make(map[string]inferencev1alpha1.AllocationDetails)
-	allocDetails["pod-uuid"] = inferencev1alpha1.AllocationDetails{Namespace: instaSliceOperatorNamespace, PodName: "test-pod", Allocationstatus: inferencev1alpha1.AllocationStatusDeleted}
+	allocDetails["pod-uuid"] = inferencev1alpha1.AllocationDetails{Namespace: InstaSliceOperatorNamespace, PodName: "test-pod", Allocationstatus: inferencev1alpha1.AllocationStatusDeleted}
 	instaslice.Spec = inferencev1alpha1.InstasliceSpec{
 		Allocations: allocDetails,
 	}
@@ -819,7 +819,7 @@ func TestInstasliceReconciler_podMapFunc(t *testing.T) {
 		args   args
 		want   []reconcile.Request
 	}{
-		{"test-case-1", newFields, newArgs, []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: instaSliceOperatorNamespace, Name: "test-pod"}}}},
+		{"test-case-1", newFields, newArgs, []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: InstaSliceOperatorNamespace, Name: "test-pod"}}}},
 		{"test-case-2", newFields, *new(args), nil},
 	}
 	for _, tt := range tests {
@@ -862,14 +862,14 @@ func TestFirstFitPolicy_SetAllocationDetails(t *testing.T) {
 		discoveredGiprofile: 0,
 		Ciprofileid:         0,
 		Ciengprofileid:      0,
-		namespace:           instaSliceOperatorNamespace,
+		namespace:           InstaSliceOperatorNamespace,
 		podName:             "test-pod",
 		gpuUuid:             "A-100",
 		resourceIdentifier:  "abcd-1234",
 		cpuMilli:            500,
 		memory:              1024,
 	}
-	allocDetails := inferencev1alpha1.AllocationDetails{PodUUID: "test-pod-uuid", Start: 0, Size: 1, Profile: "1g.5gb", GPUUUID: "A-100", Nodename: "kind-control-plane", Allocationstatus: inferencev1alpha1.AllocationStatus("created"), Resourceidentifier: "abcd-1234", Namespace: instaSliceOperatorNamespace, PodName: "test-pod", Cpu: 500, Memory: 1024}
+	allocDetails := inferencev1alpha1.AllocationDetails{PodUUID: "test-pod-uuid", Start: 0, Size: 1, Profile: "1g.5gb", GPUUUID: "A-100", Nodename: "kind-control-plane", Allocationstatus: inferencev1alpha1.AllocationStatus("created"), Resourceidentifier: "abcd-1234", Namespace: InstaSliceOperatorNamespace, PodName: "test-pod", Cpu: 500, Memory: 1024}
 	tests := []struct {
 		name string
 		args args

--- a/internal/controller/pod_webhook.go
+++ b/internal/controller/pod_webhook.go
@@ -154,7 +154,7 @@ func performQuotaArithmetic(pod *v1.Pod, req admission.Request) admission.Respon
 				acceleratorMemory := memoryValue * int(quantity.Value())
 				// assume 1 container workload
 				// Convert the string to ResourceName
-				resourceName := v1.ResourceName(quotaResourceName)
+				resourceName := v1.ResourceName(QuotaResourceName)
 				pod.Spec.Containers[0].Resources.Limits[resourceName] = resource.MustParse(fmt.Sprintf("%dGi", acceleratorMemory))
 			}
 		}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,5 +1,5 @@
 package controller
 
 func AppendToInstaSlicePrefix(suffix string) string {
-	return orgInstaslicePrefix + suffix
+	return OrgInstaslicePrefix + suffix
 }


### PR DESCRIPTION
This change will allows us to add a CI label to enforce manual GPU testing whenever the code in daemonset changes. 