### PR TITLE
use new deamonset-ocp in konflux

### DIFF
--- a/.tekton/instaslice-daemonset-pull-request.yaml
+++ b/.tekton/instaslice-daemonset-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: Dockerfile.daemonset
+    value: Dockerfile.daemonset-ocp
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/instaslice-daemonset-push.yaml
+++ b/.tekton/instaslice-daemonset-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset:{{revision}}
   - name: dockerfile
-    value: Dockerfile.daemonset
+    value: Dockerfile.daemonset-ocp
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Need to changed the dockerfile that konflux was pointing to for building the daemonset now that there is an OCP specific file.  This is a follow up to PR 244.