### PR TITLE
limit triggers to related files

### DIFF
--- a/.tekton/instaslice-daemonset-pull-request.yaml
+++ b/.tekton/instaslice-daemonset-pull-request.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('internal\/controller\/daemonset\/.*|cmd\/daemonset\/.*|\.tekton\/.*daemonset.*|Dockerfile\.daemonset.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-daemonset-push.yaml
+++ b/.tekton/instaslice-daemonset-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"  && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('internal\/controller\/daemonset\/.*|cmd\/daemonset\/.*|\.tekton\/.*daemonset.*|Dockerfile\.daemonset.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-bundle-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-pull-request.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('bundle.*|\.tekton\/.*bundle.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-bundle-push.yaml
+++ b/.tekton/instaslice-operator-bundle-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('bundle.*|\.tekton\/.*bundle.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-pull-request.yaml
+++ b/.tekton/instaslice-operator-pull-request.yaml
@@ -7,8 +7,11 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, !path.matches(bundle.*|\.tekton\/.*bundle.*)) &&
+      files.all.exists(path, !path.matches('internal\/controller\/daemonset\/.*|cmd\/daemonset\/.*|\.tekton\/.*daemonset.*|Dockerfile\.daemonset.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-push.yaml
+++ b/.tekton/instaslice-operator-push.yaml
@@ -6,8 +6,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "main" &&
+      files.all.exists(path, !path.matches(bundle.*|\.tekton\/.*bundle.*)) &&
+      files.all.exists(path, !path.matches('internal\/controller\/daemonset\/.*|cmd\/daemonset\/.*|\.tekton\/.*daemonset.*|Dockerfile\.daemonset.*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer


### PR DESCRIPTION
This updated the CEL expression which konflux uses to determine which images need to be rebuild based on which files have changed.
Did some testing of paths with https://rextester.com/tester againts the matching expressions.