### PR TITLE
Implement packing at GPU dimension

### DIFF
--- a/internal/controller/capacity.go
+++ b/internal/controller/capacity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -59,7 +60,14 @@ func (r *InstasliceReconciler) findNodeAndDeviceForASlice(ctx context.Context, i
 	}
 	if userCpuCoresCeil < nodeAvailableCpu && userMemoryBytes < nodeAvailableMemory {
 		//TODO: discover this value, this may work for A100 and H100 for now.
+		var gpuUUIDs []string
 		for gpuuuid := range updatedInstaSliceObject.Spec.MigGPUUUID {
+			gpuUUIDs = append(gpuUUIDs, gpuuuid)
+		}
+
+		// Sort the keys
+		sort.Strings(gpuUUIDs)
+		for _, gpuuuid := range gpuUUIDs {
 			if updatedInstaSliceObject.Spec.Allocations == nil {
 				updatedInstaSliceObject.Spec.Allocations = make(map[string]inferencev1alpha1.AllocationDetails)
 			}

--- a/internal/controller/capacity.go
+++ b/internal/controller/capacity.go
@@ -60,13 +60,7 @@ func (r *InstasliceReconciler) findNodeAndDeviceForASlice(ctx context.Context, i
 	}
 	if userCpuCoresCeil < nodeAvailableCpu && userMemoryBytes < nodeAvailableMemory {
 		//TODO: discover this value, this may work for A100 and H100 for now.
-		var gpuUUIDs []string
-		for gpuuuid := range updatedInstaSliceObject.Spec.MigGPUUUID {
-			gpuUUIDs = append(gpuUUIDs, gpuuuid)
-		}
-
-		// Sort the keys
-		sort.Strings(gpuUUIDs)
+		gpuUUIDs := sortGPUs(updatedInstaSliceObject)
 		for _, gpuuuid := range gpuUUIDs {
 			if updatedInstaSliceObject.Spec.Allocations == nil {
 				updatedInstaSliceObject.Spec.Allocations = make(map[string]inferencev1alpha1.AllocationDetails)
@@ -88,6 +82,15 @@ func (r *InstasliceReconciler) findNodeAndDeviceForASlice(ctx context.Context, i
 	}
 
 	return nil, fmt.Errorf("failed to find allocatable node and gpu")
+}
+
+func sortGPUs(updatedInstaSliceObject *inferencev1alpha1.Instaslice) []string {
+	gpuUUIDs := make([]string, 0, len(updatedInstaSliceObject.Spec.MigGPUUUID))
+	for gpuuuid := range updatedInstaSliceObject.Spec.MigGPUUUID {
+		gpuUUIDs = append(gpuUUIDs, gpuuuid)
+	}
+	sort.Strings(gpuUUIDs)
+	return gpuUUIDs
 }
 
 // accounting logic that finds the correct GPU and index where a slice could be placed.

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -407,6 +408,10 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// pod does not have an allocation yet, make allocation
 		// find the node
 		if !podHasNodeAllocation {
+			sort.Slice(instasliceList.Items, func(i, j int) bool {
+				// Sort by Name in ascending order
+				return instasliceList.Items[i].Name < instasliceList.Items[j].Name
+			})
 			for _, instaslice := range instasliceList.Items {
 				// find the GPU on the node and the GPU index where the slice can be created
 				allocDetails, err := r.findNodeAndDeviceForASlice(ctx, &instaslice, profileName, policy, pod)

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -884,3 +884,23 @@ func TestFirstFitPolicy_SetAllocationDetails(t *testing.T) {
 		})
 	}
 }
+
+func TestGPUSort(t *testing.T) {
+	var _ = Describe("SortGPUs", func() {
+		It("should sort GPU UUIDs in ascending order", func() {
+			instaslice := &inferencev1alpha1.Instaslice{
+				Spec: inferencev1alpha1.InstasliceSpec{
+					MigGPUUUID: map[string]string{
+						"gpu3": "uuid3",
+						"gpu1": "uuid1",
+						"gpu2": "uuid2",
+					},
+				},
+			}
+			sortedUUIDs := sortGPUs(instaslice)
+			expected := []string{"gpu1", "gpu2", "gpu3"}
+
+			Expect(sortedUUIDs).To(Equal(expected))
+		})
+	})
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -472,14 +472,25 @@ var _ = Describe("controller", Ordered, func() {
 					return false
 				}
 
-				// Check if all allocations are in the 'ungated' state
+				var assignedGPUUUID string
+				allAssignedToOneGPU := true
+
+				// Check if all allocations are in the 'ungated' state and assigned to the same GPU
 				for _, allocation := range instaslice.Spec.Allocations {
 					if allocation.Allocationstatus != inferencev1alpha1.AllocationStatusUngated {
 						return false
 					}
+
+					// Check GPUUUID consistency
+					if assignedGPUUUID == "" {
+						assignedGPUUUID = allocation.GPUUUID
+					} else if allocation.GPUUUID != assignedGPUUUID {
+						allAssignedToOneGPU = false
+						break
+					}
 				}
 
-				return true
+				return allAssignedToOneGPU
 			}, "100s", "5s").Should(BeTrue(), "Not all allocations are in the 'ungated' state after the timeout")
 		})
 		It("should verify that the Kubernetes node has the specified resource and matches total GPU memory", func() {


### PR DESCRIPTION
This PR packs slices on a GPU when possible reducing fragmentation in the cluster.
 make test, make test-e2e, make lint and daemonset shell scripts all pass.
Fixes #51 