### PR TITLE
fix max slice creation per GPU

### DIFF
--- a/internal/controller/capacity.go
+++ b/internal/controller/capacity.go
@@ -133,7 +133,7 @@ func (*InstasliceReconciler) getStartIndexFromPreparedState(instaslice *inferenc
 				break
 			}
 			if neededContinousSlot == 2 {
-				if value+neededContinousSlot < len(gpuAllocatedIndex) {
+				if value+neededContinousSlot <= len(gpuAllocatedIndex) {
 					if gpuAllocatedIndex[value] == 0 && gpuAllocatedIndex[value+1] == 0 {
 						newStart = uint32(value)
 						break
@@ -142,7 +142,7 @@ func (*InstasliceReconciler) getStartIndexFromPreparedState(instaslice *inferenc
 
 			}
 			if neededContinousSlot == 4 {
-				if value+neededContinousSlot < len(gpuAllocatedIndex) {
+				if value+neededContinousSlot <= len(gpuAllocatedIndex) {
 					if gpuAllocatedIndex[value] == 0 && gpuAllocatedIndex[value+1] == 0 && gpuAllocatedIndex[value+2] == 0 && gpuAllocatedIndex[value+3] == 0 {
 						newStart = uint32(value)
 						break
@@ -152,7 +152,7 @@ func (*InstasliceReconciler) getStartIndexFromPreparedState(instaslice *inferenc
 
 			if neededContinousSlot == 8 {
 				//special case
-				if value+neededContinousSlot < len(gpuAllocatedIndex) {
+				if value+neededContinousSlot <= len(gpuAllocatedIndex) {
 					if gpuAllocatedIndex[value] == 0 && gpuAllocatedIndex[value+1] == 0 &&
 						gpuAllocatedIndex[value+2] == 0 && gpuAllocatedIndex[value+3] == 0 &&
 						gpuAllocatedIndex[value+4] == 0 && gpuAllocatedIndex[value+5] == 0 &&

--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -233,6 +233,7 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 				for _, migDevice := range createdMigInfos {
 					if migDevice.uuid == allocations.GPUUUID && migDevice.start == allocations.Start {
 						createCiAndGi = false
+						log.Info("skipping ci and gi creation for ", "pod", allocations.PodName, "parentgpu", allocations.GPUUUID, "start", allocations.Start)
 						break
 					}
 				}


### PR DESCRIPTION
This fix allows InstaSlice to create max slices for target profile per GPU as per vendor specification.