### PR TITLE
Refactor code while updating instaslice allocations

### DIFF
--- a/Dockerfile.daemonset
+++ b/Dockerfile.daemonset
@@ -29,11 +29,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY cmd/daemonset/main.go cmd/daemonset/main.go
-COPY api/ api/
-COPY internal/controller/daemonset/instaslice_daemonset.go internal/controller/daemonset/instaslice_daemonset.go
-COPY internal/controller/constants.go internal/controller/constants.go
-COPY internal/controller/utils.go internal/controller/utils.go
+COPY . .
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/Dockerfile.daemonset-ocp
+++ b/Dockerfile.daemonset-ocp
@@ -1,17 +1,9 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS build
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY vendor vendor
 
 # Copy the go source
-COPY cmd/daemonset/main.go cmd/daemonset/main.go
-COPY api/ api/
-COPY internal/controller/daemonset/instaslice_daemonset.go internal/controller/daemonset/instaslice_daemonset.go
-COPY internal/controller/constants.go internal/controller/constants.go
-COPY internal/controller/utils.go internal/controller/utils.go
+COPY . .
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	"github.com/openshift/instaslice-operator/internal/controller/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -253,18 +254,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			for podUuid, allocation := range instaslice.Spec.Allocations {
 				if podUuid == string(pod.UID) && (allocation.Allocationstatus == inferencev1alpha1.AllocationStatusCreated) {
 					allocation.Allocationstatus = inferencev1alpha1.AllocationStatusDeleting
-					var updateInstasliceObject inferencev1alpha1.Instaslice
-					typeNamespacedName := types.NamespacedName{
-						Name:      instaslice.Name,
-						Namespace: InstaSliceOperatorNamespace,
-					}
-					err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
-					if err != nil {
-						return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-					}
-					updateInstasliceObject.Spec.Allocations[podUuid] = allocation
-					errUpdatingInstaslice := r.Update(ctx, &updateInstasliceObject)
-					if errUpdatingInstaslice != nil {
+					if errUpdatingInstaslice := utils.UpdateInstasliceAllocations(ctx, r.Client, instaslice.Name, podUuid, allocation); errUpdatingInstaslice != nil {
 						log.Info("unable to set instaslice to state deleted for ungated", "pod", allocation.PodName)
 						return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 					}
@@ -309,18 +299,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 						elapsed := time.Since(pod.DeletionTimestamp.Time)
 						if elapsed > 30*time.Second {
 							allocation.Allocationstatus = inferencev1alpha1.AllocationStatusDeleting
-							var updateInstasliceObject inferencev1alpha1.Instaslice
-							typeNamespacedName := types.NamespacedName{
-								Name:      instaslice.Name,
-								Namespace: InstaSliceOperatorNamespace,
-							}
-							err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
-							if err != nil {
-								return ctrl.Result{Requeue: true}, nil
-							}
-							updateInstasliceObject.Spec.Allocations[podUuid] = allocation
-							errUpdatingInstaslice := r.Update(ctx, &updateInstasliceObject)
-							if errUpdatingInstaslice != nil {
+							if errUpdatingInstaslice := utils.UpdateInstasliceAllocations(ctx, r.Client, instaslice.Name, podUuid, allocation); errUpdatingInstaslice != nil {
 								log.Info("unable to set instaslice to state deleted for ", "pod", allocation.PodName)
 								return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 							}
@@ -367,25 +346,8 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		for _, instaslice := range instasliceList.Items {
 			for podUuid, allocations := range instaslice.Spec.Allocations {
 				if allocations.Allocationstatus == inferencev1alpha1.AllocationStatusCreated && allocations.PodUUID == string(pod.UID) {
-					var updateInstasliceObject inferencev1alpha1.Instaslice
-					typeNamespacedName := types.NamespacedName{
-						Name:      instaslice.Name,
-						Namespace: InstaSliceOperatorNamespace,
-					}
-					errRetrievingInstaSlice := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
-					if errRetrievingInstaSlice != nil {
-						log.Error(errRetrievingInstaSlice, "error getting latest instaslice object")
-						// In some cases the pod gets ungated but the InstaSlice object does not have the
-						// correct allocation status. It could be because we were unable to get the latest InstaSlice object
-						// hence we retry if we fail to get the latest object
-						return ctrl.Result{Requeue: true}, nil
-					}
 					allocations.Allocationstatus = inferencev1alpha1.AllocationStatusUngated
-					if updateInstasliceObject.Spec.Allocations == nil {
-						updateInstasliceObject.Spec.Allocations = make(map[string]inferencev1alpha1.AllocationDetails)
-					}
-					updateInstasliceObject.Spec.Allocations[podUuid] = allocations
-					if err := r.Update(ctx, &updateInstasliceObject); err != nil {
+					if err := utils.UpdateInstasliceAllocations(ctx, r.Client, instaslice.Name, podUuid, allocations); err != nil {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					result, err := r.addNodeSelectorAndUngatePod(ctx, pod, allocations)
@@ -415,21 +377,8 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 				podHasNodeAllocation = true
 				if podHasNodeAllocation {
-					var updateInstasliceObject inferencev1alpha1.Instaslice
-					typeNamespacedName := types.NamespacedName{
-						Name:      instaslice.Name,
-						Namespace: InstaSliceOperatorNamespace,
-					}
-					err := r.Get(ctx, typeNamespacedName, &updateInstasliceObject)
+					err := utils.UpdateInstasliceAllocations(ctx, r.Client, instaslice.Name, string(pod.UID), *allocDetails)
 					if err != nil {
-						return ctrl.Result{Requeue: true}, nil
-					}
-					log.Info("allocation obtained for ", "pod", allocDetails.PodName)
-					if updateInstasliceObject.Spec.Allocations == nil {
-						updateInstasliceObject.Spec.Allocations = make(map[string]inferencev1alpha1.AllocationDetails)
-					}
-					updateInstasliceObject.Spec.Allocations[string(pod.UID)] = *allocDetails
-					if err := r.Update(ctx, &updateInstasliceObject); err != nil {
 						return ctrl.Result{Requeue: true}, nil
 					}
 					//allocation was successful

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const InstaSliceOperatorNamespace = "instaslice-system"
+
+func UpdateInstasliceAllocations(ctx context.Context, client client.Client, name, podUUID string, allocation inferencev1alpha1.AllocationDetails) error {
+	var newInstaslice inferencev1alpha1.Instaslice
+	typeNamespacedName := types.NamespacedName{
+		Name:      name,
+		Namespace: InstaSliceOperatorNamespace,
+	}
+	err := client.Get(ctx, typeNamespacedName, &newInstaslice)
+	if err != nil {
+		return fmt.Errorf("error fetching the instaslice object: %s", name)
+	}
+	if newInstaslice.Spec.Allocations == nil {
+		newInstaslice.Spec.Allocations = make(map[string]inferencev1alpha1.AllocationDetails)
+	}
+	newInstaslice.Spec.Allocations[podUUID] = allocation
+	err = client.Update(ctx, &newInstaslice)
+	if err != nil {
+		return fmt.Errorf("error updating the instaslie object, %s, err: %v", name, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Move update of instaslice object with the new allocations to a utils package so that it can be leveraged both by the controller and the daemonset.

`make test`, `make test-e2e-kind-emulated`, `make lint` are passing