### PR TITLE
Add unit tests for the daemonset

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -20,8 +20,8 @@ import "time"
 
 const (
 	OrgInstaslicePrefix              = "instaslice.redhat.com/"
-	gateName                         = OrgInstaslicePrefix + "accelerator"
-	finalizerName                    = gateName
+	GateName                         = OrgInstaslicePrefix + "accelerator"
+	FinalizerName                    = GateName
 	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
 	EmulatorModeFalse                = "false"
 	EmulatorModeTrue                 = "true"

--- a/internal/controller/daemonset/OWNERS
+++ b/internal/controller/daemonset/OWNERS
@@ -2,6 +2,7 @@
 approvers:
 - harche
 - asm582
+- sairameshv
 
 options:
   no_parent_owners: true

--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -563,7 +563,14 @@ func (r *InstaSliceDaemonsetReconciler) classicalResourcesAndGPUMemOnNode(ctx co
 	newResourceQuantity := resource.MustParse(totalGPUMemory + "Gi")
 	// Convert the string to ResourceName
 	resourceName := v1.ResourceName(controller.QuotaResourceName)
-	node.Status.Capacity[resourceName] = newResourceQuantity
+	if node.Status.Capacity == nil {
+		resourceList := v1.ResourceList{
+			resourceName: newResourceQuantity,
+		}
+		node.Status.Capacity = resourceList
+	} else {
+		node.Status.Capacity[resourceName] = newResourceQuantity
+	}
 
 	if err := r.Status().Update(ctx, node); err != nil {
 		log.Error(err, "unable to patch the node with new resource")

--- a/internal/controller/daemonset/instaslice_daemonset_test.go
+++ b/internal/controller/daemonset/instaslice_daemonset_test.go
@@ -18,16 +18,22 @@ package daemonset
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	"github.com/openshift/instaslice-operator/internal/controller"
 )
 
 func TestDeleteConfigMap(t *testing.T) {
@@ -66,4 +72,372 @@ func TestDeleteConfigMap(t *testing.T) {
 	// Test Case 2: ConfigMap not found
 	err = reconciler.deleteConfigMap(ctx, "non-existent-configmap", "default")
 	assert.NoError(t, err, "expected no error when configmap is not found")
+}
+
+func TestInstaSliceDaemonsetReconciler_Reconcile_Deleting_Alloc_Status(t *testing.T) {
+	// Set up the scheme for the client
+	s := scheme.Scheme
+	_ = v1.AddToScheme(s)
+	_ = inferencev1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+
+	// Use the fake client
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+	const (
+		nodeName = "test-node"
+		podUUID  = "test-pod-uuid"
+	)
+	// Set NODE_NAME and EMULATOR_MODE env variables
+	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
+	assert.NoError(t, os.Setenv("EMULATOR_MODE", controller.EmulatorModeTrue))
+
+	// Create the reconciler with the fake client
+	reconciler := &InstaSliceDaemonsetReconciler{
+		Client:   client,
+		NodeName: nodeName,
+	}
+
+	// Create a background context
+	ctx := context.Background()
+
+	// Create an instaslice object
+	instaslice := newInstaslice(nodeName, podUUID, inferencev1alpha1.AllocationStatusDeleting)
+	typeNamespacedName := types.NamespacedName{
+		Name:      nodeName,
+		Namespace: controller.InstaSliceOperatorNamespace,
+	}
+	req := ctrl.Request{
+		NamespacedName: typeNamespacedName,
+	}
+
+	// Testcase 1: reconcile on an unknown instaslice object's name
+	req.Name = "unknown-node"
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, result, ctrl.Result{})
+
+	// Testcase 2: reconcile when an Instaslice object is not present
+	req.Name = nodeName
+	result, err = reconciler.Reconcile(ctx, req)
+	assert.Error(t, err)
+	assert.Equal(t, result, ctrl.Result{})
+
+	// Testcase 3: reconcile for an AllocationStatusDeleting
+	assert.NoError(t, reconciler.Client.Create(ctx, instaslice))
+	result, err = reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, result, ctrl.Result{})
+}
+
+func TestInstaSliceDaemonsetReconciler_Reconcile_Creating_Alloc_Status(t *testing.T) {
+	// Set up the scheme for the client
+	s := scheme.Scheme
+	_ = v1.AddToScheme(s)
+	_ = inferencev1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	const (
+		nodeName = "test-node"
+		podUUID  = "test-pod-uuid"
+	)
+	// Use the fake client
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+
+	// Set NODE_NAME and EMULATOR_MODE env variables
+	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
+	assert.NoError(t, os.Setenv("EMULATOR_MODE", controller.EmulatorModeTrue))
+
+	// Create the reconciler with the fake client
+	reconciler := &InstaSliceDaemonsetReconciler{
+		Client:   client,
+		NodeName: nodeName,
+	}
+
+	// Create a background context
+	ctx := context.Background()
+
+	// Create an instaslice object
+	instaslice := newInstaslice(nodeName, podUUID, inferencev1alpha1.AllocationStatusCreating)
+	typeNamespacedName := types.NamespacedName{
+		Name:      nodeName,
+		Namespace: controller.InstaSliceOperatorNamespace,
+	}
+	req := ctrl.Request{
+		NamespacedName: typeNamespacedName,
+	}
+
+	// Testcase 4: reconcile for an AllocationStatusDeleting
+	assert.NoError(t, reconciler.Client.Create(ctx, instaslice))
+	result, err := reconciler.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.Equal(t, result, ctrl.Result{})
+}
+
+func newInstaslice(name, podUUID string, status inferencev1alpha1.AllocationStatus) *inferencev1alpha1.Instaslice {
+	// Create an instaslice object
+	instaslice := new(inferencev1alpha1.Instaslice)
+	instaslice.Name = name
+	instaslice.Namespace = controller.InstaSliceOperatorNamespace
+	spec := inferencev1alpha1.InstasliceSpec{
+		Allocations: map[string]inferencev1alpha1.AllocationDetails{
+			podUUID: {
+				PodUUID:            podUUID,
+				Allocationstatus:   status,
+				Nodename:           name,
+				Resourceidentifier: name,
+			},
+		},
+	}
+	instaslice.Spec = spec
+	return instaslice
+}
+
+func Test_calculateTotalMemoryGB(t *testing.T) {
+	type args struct {
+		gpuInfoList map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{"test-1", args{map[string]string{"gpu-1": "1g.5GB", "gpu-2": "2g.10GB"}}, 15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, calculateTotalMemoryGB(tt.args.gpuInfoList), "calculateTotalMemoryGB(%v)", tt.args.gpuInfoList)
+		})
+	}
+}
+
+func TestInstaSliceDaemonsetReconciler_addMigCapacityToNode(t *testing.T) {
+	// Set up the scheme for the client
+	s := scheme.Scheme
+	_ = v1.AddToScheme(s)
+	_ = inferencev1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+
+	const (
+		nodeName = "test-node"
+		podUUID  = "test-pod-uuid"
+	)
+
+	// Use the fake client
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+
+	// Set NODE_NAME and EMULATOR_MODE env variables
+	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
+	assert.NoError(t, os.Setenv("EMULATOR_MODE", controller.EmulatorModeTrue))
+
+	// Create the reconciler with the fake client
+	reconciler := &InstaSliceDaemonsetReconciler{
+		Client:   client,
+		NodeName: nodeName,
+	}
+
+	// Create a background context
+	ctx := context.Background()
+
+	// create a fake node object
+	node := &v1.Node{}
+	node.Name = nodeName
+	assert.NoError(t, client.Create(ctx, node))
+	// Create an instaslice object
+	instaslice := newInstaslice(nodeName, podUUID, inferencev1alpha1.AllocationStatusCreating)
+	assert.NoError(t, reconciler.addMigCapacityToNode(ctx, instaslice))
+}
+
+func TestInstaSliceDaemonsetReconciler_classicalResourcesAndGPUMemOnNode(t *testing.T) {
+	// Set up the scheme for the client
+	s := scheme.Scheme
+	_ = v1.AddToScheme(s)
+	_ = inferencev1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+
+	nodeName := "test-node"
+
+	// Use the fake client
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+
+	// Set NODE_NAME and EMULATOR_MODE env variables
+	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
+	assert.NoError(t, os.Setenv("EMULATOR_MODE", controller.EmulatorModeTrue))
+
+	// Create the reconciler with the fake client
+	reconciler := &InstaSliceDaemonsetReconciler{
+		Client:   client,
+		NodeName: nodeName,
+	}
+	// Create a background context
+	ctx := context.Background()
+	// create a fake node object
+	node := &v1.Node{}
+	node.Name = nodeName
+	node.Status.Allocatable = v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("10m"),
+		v1.ResourceMemory: resource.MustParse("500Mi"),
+	}
+
+	assert.NoError(t, client.Create(ctx, node))
+	cpu, mem, err := reconciler.classicalResourcesAndGPUMemOnNode(ctx, nodeName, "30")
+	assert.Equal(t, int64(1), cpu)
+	assert.Equal(t, int64(524288000), mem)
+	assert.NoError(t, err)
+}
+
+func TestNewMigProfile(t *testing.T) {
+	type args struct {
+		giProfileID            int
+		ciProfileID            int
+		ciEngProfileID         int
+		giSliceCount           uint32
+		ciSliceCount           uint32
+		migMemorySizeMB        uint64
+		totalDeviceMemoryBytes uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want *MigProfile
+	}{
+		{"test-case-1", args{
+			giProfileID:            1,
+			ciProfileID:            2,
+			ciEngProfileID:         3,
+			giSliceCount:           4,
+			ciSliceCount:           5,
+			migMemorySizeMB:        32,
+			totalDeviceMemoryBytes: 64,
+		}, &MigProfile{
+			C:              5,
+			G:              4,
+			GB:             int(getMigMemorySizeInGB(64, 32)),
+			GIProfileID:    1,
+			CIProfileID:    2,
+			CIEngProfileID: 3,
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, NewMigProfile(tt.args.giProfileID, tt.args.ciProfileID, tt.args.ciEngProfileID, tt.args.giSliceCount, tt.args.ciSliceCount, tt.args.migMemorySizeMB, tt.args.totalDeviceMemoryBytes), "NewMigProfile(%v, %v, %v, %v, %v, %v, %v)", tt.args.giProfileID, tt.args.ciProfileID, tt.args.ciEngProfileID, tt.args.giSliceCount, tt.args.ciSliceCount, tt.args.migMemorySizeMB, tt.args.totalDeviceMemoryBytes)
+		})
+	}
+}
+
+func Test_getMigMemorySizeInGB(t *testing.T) {
+	type args struct {
+		totalDeviceMemory uint64
+		migMemorySizeMB   uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint64
+	}{
+		{"test-case", args{1, 1}, 0x100000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getMigMemorySizeInGB(tt.args.totalDeviceMemory, tt.args.migMemorySizeMB), "getMigMemorySizeInGB(%v, %v)", tt.args.totalDeviceMemory, tt.args.migMemorySizeMB)
+		})
+	}
+}
+
+func TestMigProfile_String(t *testing.T) {
+	type fields struct {
+		C              int
+		G              int
+		GB             int
+		GIProfileID    int
+		CIProfileID    int
+		CIEngProfileID int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{"test-case-1", fields{1, 2, 3, 4, 5, 6}, "1c.2g.3gb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := MigProfile{
+				C:              tt.fields.C,
+				G:              tt.fields.G,
+				GB:             tt.fields.GB,
+				GIProfileID:    tt.fields.GIProfileID,
+				CIProfileID:    tt.fields.CIProfileID,
+				CIEngProfileID: tt.fields.CIEngProfileID,
+			}
+			assert.Equalf(t, tt.want, m.String(), "String()")
+		})
+	}
+}
+
+func TestMigProfile_Attributes(t *testing.T) {
+	type fields struct {
+		C              int
+		G              int
+		GB             int
+		GIProfileID    int
+		CIProfileID    int
+		CIEngProfileID int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{"test-case-1", fields{1, 2, 3, 7, 5, 6}, []string{"me"}},
+		{"test-case-2", fields{1, 2, 3, 4, 5, 6}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := MigProfile{
+				C:              tt.fields.C,
+				G:              tt.fields.G,
+				GB:             tt.fields.GB,
+				GIProfileID:    tt.fields.GIProfileID,
+				CIProfileID:    tt.fields.CIProfileID,
+				CIEngProfileID: tt.fields.CIEngProfileID,
+			}
+			assert.Equalf(t, tt.want, m.Attributes(), "Attributes()")
+		})
+	}
+}
+
+func TestInstaSliceDaemonsetReconciler_checkConfigMapExists(t *testing.T) {
+	// Set up the scheme for the client
+	s := scheme.Scheme
+	_ = v1.AddToScheme(s)
+	_ = inferencev1alpha1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+
+	nodeName := "test-node"
+
+	// Use the fake client
+	client := fake.NewClientBuilder().WithScheme(s).Build()
+
+	// Set NODE_NAME and EMULATOR_MODE env variables
+	assert.NoError(t, os.Setenv("NODE_NAME", nodeName))
+	assert.NoError(t, os.Setenv("EMULATOR_MODE", controller.EmulatorModeTrue))
+
+	// Create the reconciler with the fake client
+	reconciler := &InstaSliceDaemonsetReconciler{
+		Client:   client,
+		NodeName: nodeName,
+	}
+	// Create a background context
+	ctx := context.Background()
+	configMap := &v1.ConfigMap{}
+	configMap.Name = nodeName
+	configMap.Namespace = controller.InstaSliceOperatorNamespace
+	// create a config map
+	assert.NoError(t, reconciler.Create(ctx, configMap))
+	exists, err := reconciler.checkConfigMapExists(ctx, nodeName, controller.InstaSliceOperatorNamespace)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	// check for non-existent config map
+	exists, err = reconciler.checkConfigMapExists(ctx, "test-configmap", controller.InstaSliceOperatorNamespace)
+	assert.NoError(t, err)
+	assert.True(t, !exists)
 }

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -36,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
@@ -85,7 +85,7 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 			}
@@ -135,7 +135,7 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 
 			updatedPod := &v1.Pod{}
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedPod)).To(Succeed())
-			Expect(updatedPod.Finalizers).NotTo(ContainElement(finalizerName))
+			Expect(updatedPod.Finalizers).NotTo(ContainElement(FinalizerName))
 		})
 
 		It("should set allocation status to Deleting if status is not Deleted", func() {
@@ -351,7 +351,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Status: v1.PodStatus{Phase: v1.PodPending, Conditions: []v1.PodCondition{{Message: "blocked"}}},
@@ -449,7 +449,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 		It("should return if the containers are not present", func() {
 			// update the scheduling gates of the pod by unknown name
 			pod.Spec.SchedulingGates = append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{
-				Name: gateName,
+				Name: GateName,
 			})
 			pod.Finalizers = nil
 			Expect(fakeClient.Update(ctx, pod)).To(Succeed())
@@ -471,11 +471,11 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					// to process the allocations
 					UID: types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Spec: v1.PodSpec{
-					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: gateName}),
+					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: GateName}),
 				},
 				Status: v1.PodStatus{Phase: v1.PodFailed, Conditions: []v1.PodCondition{{Message: "blocked"}}},
 			}
@@ -498,7 +498,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			Expect(result).To(Equal(ctrl.Result{}))
 			newPod := &v1.Pod{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: failedPodName, Namespace: InstaSliceOperatorNamespace}, newPod)).To(Succeed())
-			Expect(newPod.Finalizers).ToNot(ContainElement(finalizerName))
+			Expect(newPod.Finalizers).ToNot(ContainElement(FinalizerName))
 
 		})
 
@@ -514,11 +514,11 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					// to process the allocations
 					UID: types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Spec: v1.PodSpec{
-					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: gateName}),
+					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: GateName}),
 				},
 				Status: v1.PodStatus{Phase: v1.PodSucceeded, Conditions: []v1.PodCondition{{Message: "blocked"}}},
 			}
@@ -541,7 +541,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 			Expect(result).To(Equal(ctrl.Result{}))
 			newPod := &v1.Pod{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: succeededPodName, Namespace: InstaSliceOperatorNamespace}, newPod)).To(Succeed())
-			Expect(newPod.Finalizers).ToNot(ContainElement(finalizerName))
+			Expect(newPod.Finalizers).ToNot(ContainElement(FinalizerName))
 
 		})
 
@@ -555,11 +555,11 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					// to process the allocations
 					UID: types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Spec: v1.PodSpec{
-					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: gateName}),
+					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: GateName}),
 					Containers:      []v1.Container{{Name: "test-container-1"}, {Name: "test-container-2"}},
 				},
 				Status: v1.PodStatus{Phase: v1.PodPending, Conditions: []v1.PodCondition{{Message: "blocked"}}},
@@ -584,12 +584,12 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy:   v1.RestartPolicyOnFailure,
-					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: gateName}),
+					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: GateName}),
 					Containers: []v1.Container{
 						{
 							Name:  "vectoradd-cpu",
@@ -633,12 +633,12 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy:   v1.RestartPolicyOnFailure,
-					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: gateName}),
+					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: GateName}),
 					Containers: []v1.Container{
 						{
 							Name:  "vectoradd-cpu",
@@ -689,12 +689,12 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 					Namespace: InstaSliceOperatorNamespace,
 					UID:       types.UID(podUUID),
 					Finalizers: []string{
-						finalizerName,
+						FinalizerName,
 					},
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy:   v1.RestartPolicyOnFailure,
-					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: gateName}),
+					SchedulingGates: append(pod.Spec.SchedulingGates, v1.PodSchedulingGate{Name: GateName}),
 					Containers: []v1.Container{
 						{
 							Name:  "vectoradd-cpu",

--- a/internal/controller/pod_webhook.go
+++ b/internal/controller/pod_webhook.go
@@ -81,7 +81,7 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 	}
 
 	// Add scheduling
-	schedulingGateName := gateName
+	schedulingGateName := GateName
 	found := false
 	for _, gate := range pod.Spec.SchedulingGates {
 		if gate.Name == schedulingGateName {


### PR DESCRIPTION
- Add unit tests for the daemonset code that do not include the nvml calls
- Add `sairameshv` to the daemonset code approvers' list
- Minor refactors and fix

`make test-e2e-kind-emulated`, `make test`, `make lint` are passing locally

Fixes https://github.com/openshift/instaslice-operator/issues/61