### PR TITLE
select mig enabled gpus only

### DIFF
--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -600,7 +600,7 @@ func (r *InstaSliceDaemonsetReconciler) discoverAvailableProfilesOnGpus() (*infe
 		}
 
 		uuid, _ := device.GetUUID()
-		mode, _, ret := nvml.Device(device).GetMigMode()
+		mode, _, ret := device.GetMigMode()
 		if ret == nvml.ERROR_NOT_SUPPORTED {
 			return instaslice, ret, gpuModelMap, false, fmt.Errorf("unable to detect mig mode")
 		}

--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -580,6 +580,7 @@ func (r *InstaSliceDaemonsetReconciler) classicalResourcesAndGPUMemOnNode(ctx co
 
 // during init time we need to discover GPU that are MIG enabled and slices if any on them to start making allocations of the next pods.
 func (r *InstaSliceDaemonsetReconciler) discoverAvailableProfilesOnGpus() (*inferencev1alpha1.Instaslice, nvml.Return, map[string]string, bool, error) {
+	log := logr.FromContext(context.TODO())
 	instaslice := &inferencev1alpha1.Instaslice{}
 	ret := nvml.Init()
 	if ret != nvml.SUCCESS {
@@ -599,6 +600,17 @@ func (r *InstaSliceDaemonsetReconciler) discoverAvailableProfilesOnGpus() (*infe
 		}
 
 		uuid, _ := device.GetUUID()
+		mode, _, ret := nvml.Device(device).GetMigMode()
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			return instaslice, ret, gpuModelMap, false, fmt.Errorf("unable to detect mig mode")
+		}
+		if ret != nvml.SUCCESS {
+			return instaslice, ret, gpuModelMap, false, fmt.Errorf("error getting MIG mode: %v", ret)
+		}
+		if mode != nvml.DEVICE_MIG_ENABLE {
+			log.Info("mig mode not enabled on gpu with", "uuid", uuid)
+			continue
+		}
 		gpuName, _ := device.GetName()
 		gpuModelMap[uuid] = gpuName
 		discoveredGpusOnHost = append(discoveredGpusOnHost, uuid)

--- a/test/daemonset_testing_scripts/test_gpu_filtering.sh
+++ b/test/daemonset_testing_scripts/test_gpu_filtering.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <IMG> <IMG_DMST>"
+    echo "Example: $0 quay.io/amalvank/instaslice-ctrl-dev quay.io/amalvank/instaslice-dmst-dev"
+    exit 1
+fi
+
+IMG=$1
+IMG_DMST=$2
+
+# Assume all GPUs on a single node are MIG enabled
+echo "Disabling MIG mode on GPU with ID 1..."
+sudo nvidia-smi -i 1 -mig 0
+
+echo "Deploying cluster..."
+bash deploy/setup.sh
+
+echo "Deploying instaslice..."
+IMG=$IMG IMG_DMST=$IMG_DMST make deploy
+
+
+echo "Waiting for all pods in the 'instaslice-system' namespace to be running..."
+while true; do
+    POD_STATUS=$(kubectl get pods -n instaslice-system --no-headers | awk '{print $3}' | grep -v Running | wc -w)
+    if [ "$POD_STATUS" -eq 0 ]; then
+        echo "All pods are running in the 'instaslice-system' namespace."
+        break
+    fi
+    echo "Waiting for pods to be running..."
+    sleep 5
+done
+
+echo "Checking entries in instaslice.spec.MigGPUUUID..."
+MIG_UUID_COUNT=$(kubectl get instaslice -n instaslice-system -o jsonpath='{.items[*].spec.MigGPUUUID.*}' | wc -w)
+
+if [ "$MIG_UUID_COUNT" -eq 1 ]; then
+    echo "Validation successful: instaslice.spec.MIGUUID is equal to 1."
+else
+    echo "Validation failed: instaslice.spec.MIGUUID is not equal to 1. Count: $MIG_UUID_COUNT"
+    exit 1
+fi
+
+echo "Script completed successfully."


### PR DESCRIPTION
This PR adds the ability in Instaslice to select MIG-enabled GPUs on the node. This will allow users to use full GPUs and MIG-enabled GPUs on the node.