### PR TITLE
Add make target for running e2e tests for OCP using GPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,24 @@ test-e2e-ocp-emulated: export EMULATOR_MODE=true
 test-e2e-ocp-emulated: docker-build docker-push deploy-cert-manager deploy-instaslice-emulated-on-ocp
 	export KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
                 ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m ./test/e2e
+
 PHONY: cleanup-test-e2e-ocp-emulated
 cleanup-test-e2e-ocp-emulated: KUBECTL=oc
 cleanup-test-e2e-ocp-emulated: ocp-undeploy-emulated uninstall
 	${KUBECTL} delete ns instaslice-system
+
+.PHONY: test-e2e-ocp
+test-e2e-ocp: export IMG_TAG=latest
+test-e2e-ocp: export EMULATOR_MODE=false
+test-e2e-ocp: docker-build docker-push deploy-instaslice-on-ocp
+	export KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
+                ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m ./test/e2e
+
+PHONY: cleanup-test-e2e-ocp
+cleanup-test-e2e-ocp: KUBECTL=oc
+cleanup-test-e2e-ocp: ocp-undeploy
+	${KUBECTL} delete ns instaslice-system
+
 
 .PHONY: create-kind-cluster
 create-kind-cluster:
@@ -193,6 +207,11 @@ deploy-instaslice-emulated-on-kind:
 deploy-instaslice-emulated-on-ocp:
 	export  KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
                 hack/deploy-instaslice-emulated-on-ocp.sh
+
+.PHONY: deploy-instaslice-on-ocp
+deploy-instaslice-on-ocp:
+	export  KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
+                hack/deploy-instaslice-on-ocp.sh
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.61.0

--- a/hack/deploy-instaslice-on-ocp.sh
+++ b/hack/deploy-instaslice-on-ocp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+KUBECTL=${KUBECTL:-oc}
+NAMESPACE=${NAMESPACE:-"instaslice-system"}
+WEBHOOK_TIMEOUT=${WEBHOOK_TIMEOUT:-2m}
+
+_kubectl() {
+        ${KUBECTL} $@
+}
+
+echo "Creating namespace ${NAMESPACE}"
+_kubectl create ns ${NAMESPACE}
+echo "Installing instaslice CRD"
+make install
+sleep 10
+echo "Deploying Instaslice controller-manager"
+IMG=${IMG} IMG_DMST=${IMG_DMST} make ocp-deploy
+_kubectl wait --for=condition=ready pod -l control-plane=controller-manager -n ${NAMESPACE} --timeout=${WEBHOOK_TIMEOUT}


### PR DESCRIPTION
Helps to to run e2e tests on OCP using real GPUs. It is expected that user has installed and configured prerequisites such as, OCP Cert Operator, NFD Operator and Nvidia GPU Operator before invoking these tests on the cluster.  