### PR TITLE
Do not delete the namespace explicitly in cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,6 @@ test-e2e-ocp-emulated: docker-build docker-push deploy-cert-manager deploy-insta
 PHONY: cleanup-test-e2e-ocp-emulated
 cleanup-test-e2e-ocp-emulated: KUBECTL=oc
 cleanup-test-e2e-ocp-emulated: ocp-undeploy-emulated uninstall
-	${KUBECTL} delete ns instaslice-system
 
 .PHONY: create-kind-cluster
 create-kind-cluster:


### PR DESCRIPTION
`ocp-undeploy` will delete the `instaslice-system` namespace, so there is no need to explicitly remove it in the cleanup. Without this fix you would see cleanup running into following issue, 

```bash
$ make cleanup-test-e2e-ocp
/home/harshal/go/src/github.com/openshift/instaslice-operator/bin/kustomize build config/default | oc delete --ignore-not-found=false -f -
namespace "instaslice-system" deleted
customresourcedefinition.apiextensions.k8s.io "instaslices.inference.redhat.com" deleted
serviceaccount "instaslice-operator-controller-manager" deleted
role.rbac.authorization.k8s.io "instaslice-operator-leader-election-role" deleted
clusterrole.rbac.authorization.k8s.io "instaslice-operator-manager-role" deleted
clusterrole.rbac.authorization.k8s.io "instaslice-operator-metrics-reader" deleted
clusterrole.rbac.authorization.k8s.io "instaslice-operator-proxy-role" deleted
rolebinding.rbac.authorization.k8s.io "instaslice-operator-leader-election-rolebinding" deleted
clusterrolebinding.rbac.authorization.k8s.io "instaslice-operator-manager-rolebinding" deleted
clusterrolebinding.rbac.authorization.k8s.io "instaslice-operator-proxy-rolebinding" deleted
service "instaslice-operator-controller-manager-metrics-service" deleted
service "instaslice-operator-webhook-service" deleted
deployment.apps "instaslice-operator-controller-manager" deleted
certificate.cert-manager.io "instaslice-operator-serving-cert" deleted
issuer.cert-manager.io "instaslice-operator-selfsigned-issuer" deleted
mutatingwebhookconfiguration.admissionregistration.k8s.io "instaslice-operator-mutating-webhook-configuration" deleted
oc delete -f config/rbac/instaslice-operator-scc.yaml
securitycontextconstraints.security.openshift.io "instaslice-operator-scc" deleted
oc delete -f config/rbac/openshift_scc_cluster_role_binding.yaml
clusterrolebinding.rbac.authorization.k8s.io "use-scc-instaslice-operator" deleted
oc apply -f config/rbac/openshift_cluster_role.yaml
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:instaslice-operator-scc unchanged
oc delete ns instaslice-system
Error from server (NotFound): namespaces "instaslice-system" not found
make: *** [Makefile:183: cleanup-test-e2e-ocp] Error 1
```