### PR TITLE
Add focus to e2e to filter the test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,10 @@ cleanup-test-e2e-kind-emulated:
 test-e2e-ocp-emulated: export IMG_TAG=latest
 test-e2e-ocp-emulated: export EMULATOR_MODE=true
 test-e2e-ocp-emulated: docker-build docker-push deploy-instaslice-emulated-on-ocp
+	$(eval FOCUS_ARG := $(if $(FOCUS),--focus="$(FOCUS)"))
 	export KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
-                ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m ./test/e2e
+	ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m $(FOCUS_ARG) ./test/e2e
+
 PHONY: cleanup-test-e2e-ocp-emulated
 cleanup-test-e2e-ocp-emulated: KUBECTL=oc
 cleanup-test-e2e-ocp-emulated: ocp-undeploy-emulated uninstall


### PR DESCRIPTION
Helps in reducing the turn around time when debugging the test cases by individually focusing on a given test case. 

e.g. 
```bash
IMG=quay.io/harpatil/instaslice2-controller:2.4 IMG_DMST=quay.io/harpatil/instaslice2-daemonset:2.4 make test-e2e-ocp-emulated FOCUS="should verify that the Kubernetes node has the specified resource and matches total GPU memory"
```