### PR TITLE
set security context for controller deployment

### DIFF
--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -273,6 +273,8 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: instaslice-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:


### PR DESCRIPTION
this will eliminate the need to apply config/rbac/instaslice-operator-scc.yaml 