### PR TITLE
Add instaslice custom metrics

### DIFF
--- a/api/v1alpha1/instaslice_types.go
+++ b/api/v1alpha1/instaslice_types.go
@@ -182,6 +182,9 @@ type InstasliceStatus struct {
 	// nodeResources specifies the discovered resources of the node
 	// +optional
 	NodeResources DiscoveredNodeResources `json:"nodeResources"`
+	// ObservedGeneration tracks the latest generation of the resource that has been observed and acted upon by the controller
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -59,6 +59,12 @@ func init() {
 }
 
 func main() {
+	// Log info before initializing metrics exporter
+	ctrl.Log.Info("Initializing Metrics Exporter.")
+	controller.RegisterMetrics()
+	// Log info after the metrics exporter is initialized
+	ctrl.Log.Info("Metrics Exporter Initialized.")
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string

--- a/config/crd/bases/inference.redhat.com_instaslices.yaml
+++ b/config/crd/bases/inference.redhat.com_instaslices.yaml
@@ -324,6 +324,11 @@ spec:
                 - nodeGpus
                 - nodeResources
                 type: object
+              observedGeneration:
+                description: ObservedGeneration tracks the latest generation of the
+                  resource that has been observed and acted upon by the controller
+                format: int64
+                type: integer
               podAllocationResults:
                 additionalProperties:
                   properties:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,6 +78,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
+          runAsUser: 1000
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/instaslice-metrics-service.yaml
+++ b/deploy/instaslice-metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: instaslice-metrics
+  namespace: instaslice-system
+  labels:
+    control-plane: controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager  # Use the correct label here

--- a/deploy/instaslice-servicemonitor.yaml
+++ b/deploy/instaslice-servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: instaslice-monitor
+  namespace: instaslice-monitoring
+  labels:
+    release: prometheus  # Label to match Prometheus serviceMonitorSelector
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager # Match labels of the Service exposing metrics
+  namespaceSelector:
+    matchNames:
+      - instaslice-system  # Namespace where the Service resides
+  endpoints:
+    - port: metrics  # Port name exposed in the Service for kube-rbac-proxy
+      interval: 15s
+      path: /metrics
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token  # Prometheus authentication
+      honorLabels: true
+      tlsConfig:
+        insecureSkipVerify: true  # Set to false if using a valid CA

--- a/deploy/prometheus-role.yaml
+++ b/deploy/prometheus-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-metrics-reader
+  namespace: instaslice-system
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+

--- a/deploy/prometheus-rolebinding.yaml
+++ b/deploy/prometheus-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-metrics-binding
+  namespace: instaslice-system
+subjects:
+- kind: ServiceAccount
+  name: prometheus-kube-prometheus-prometheus  # Change this to your Prometheus ServiceAccount
+  namespace: instaslice-monitoring  # Change to Prometheus namespace
+roleRef:
+  kind: Role
+  name: prometheus-metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/prometheus-serviceaccount.yaml
+++ b/deploy/prometheus-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: instaslice-monitoring  # namespace where Prometheus is running

--- a/deploy/prometheus.yaml
+++ b/deploy/prometheus.yaml
@@ -1,0 +1,36 @@
+alertmanager:
+    enabled: false
+kube-state-metrics:
+    enabled: false
+prometheus-node-exporter:
+    enabled: false
+prometheus-pushgateway:
+    enabled: false
+server:
+    name: instaslice
+    service:
+        enabled: true
+        type: NodePort
+        servicePort: 9090
+    persistentVolume:
+        existingClaim: prometheus-instaslice
+        enabled: false
+    securityContext:
+        runAsUser:
+        runAsNonRoot:
+        runAsGroup:
+        fsGroup:
+extraScrapeConfigs: |
+    - job_name: instaslice-metrics
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: https
+      scrape_interval: 15s
+      static_configs:
+          - targets:
+              - instaslice-metrics.instaslice-system.svc.cluster.local:8443
+      tls_config:
+        insecure_skip_verify: true
+serviceMonitorSelector:
+    matchLabels:
+        release: prometheus

--- a/internal/controller/capacity.go
+++ b/internal/controller/capacity.go
@@ -195,6 +195,32 @@ func (*InstasliceReconciler) getStartIndexFromPreparedState(instaslice *inferenc
 	return newStart
 }
 
+// getTotalFitForProfileOnGPU checks how many times a profile can fit on a given GPU.
+func (r *InstasliceReconciler) getTotalFitForProfileOnGPU(instasliceObj *inferencev1alpha1.Instaslice, profileName string, size, remaining int32) int32 {
+	if remaining == 0 {
+		return 0
+	}
+	// Retrieve profile size
+	migPlacement, exists := instasliceObj.Status.NodeResources.MigPlacement[profileName]
+	if !exists || len(migPlacement.Placements) == 0 {
+		return 0 // Profile does not exist
+	}
+	profileSize := migPlacement.Placements[0].Size
+	gpuFit := int32(0)
+	usedSlices := int32(0)
+	// Special handling for `7g.40gb`
+	if size == 8 && remaining == 7 {
+		return 1
+	}
+	// Check if we can fit the profile multiple times
+	for usedSlices+profileSize <= remaining ||
+		(usedSlices+profileSize-1 == remaining && (profileName == "3g.20gb" || profileName == "1g.10gb")) {
+		gpuFit++
+		usedSlices += profileSize
+	}
+	return gpuFit
+}
+
 func (r *InstasliceReconciler) availableClassicalResourcesOnNode(instaslice *inferencev1alpha1.Instaslice) v1.ResourceList {
 	allocatedCpu := resource.MustParse("0")
 	allocatedMemory := resource.MustParse("0")

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -189,11 +189,11 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		for _, instaslice := range instasliceList.Items {
 			for uuid, allocation := range instaslice.Status.PodAllocationResults {
 				if pod.UID == uuid {
+					allocRequest := instaslice.Spec.PodAllocationRequests[uuid]
 					if allocation.AllocationStatus.AllocationStatusController == inferencev1alpha1.AllocationStatusCreating && allocation.AllocationStatus.AllocationStatusDaemonset == "" {
 						return ctrl.Result{RequeueAfter: Requeue2sDelay}, nil
 					}
 					if allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusCreated || allocation.AllocationStatus.AllocationStatusController == inferencev1alpha1.AllocationStatusUngated {
-						allocRequest := instaslice.Spec.PodAllocationRequests[uuid]
 						resultDeleting, err := r.setInstasliceAllocationToDeleting(ctx, instaslice.Name, &allocation, &allocRequest)
 						if err != nil {
 							return resultDeleting, nil
@@ -203,7 +203,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 						return ctrl.Result{}, nil
 					}
 					if allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
-						err := r.removeInstasliceAllocation(ctx, instaslice.Name, &allocation)
+						err := r.removeInstasliceAllocation(ctx, instaslice.Name, &allocation, &allocRequest)
 						if err != nil {
 							return ctrl.Result{}, err
 						}
@@ -231,8 +231,8 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		for _, instaslice := range instasliceList.Items {
 			for uuid, allocation := range instaslice.Status.PodAllocationResults {
 				if uuid == pod.UID {
+					allocRequest := instaslice.Spec.PodAllocationRequests[uuid]
 					if allocation.AllocationStatus.AllocationStatusDaemonset != inferencev1alpha1.AllocationStatusDeleted {
-						allocRequest := instaslice.Spec.PodAllocationRequests[uuid]
 						log.Info("setting status to deleting", "pod", pod.Name)
 						result, err := r.setInstasliceAllocationToDeleting(ctx, instaslice.Name, &allocation, &allocRequest)
 						if err != nil {
@@ -244,7 +244,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					}
 
 					if allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
-						err := r.removeInstasliceAllocation(ctx, instaslice.Name, &allocation)
+						err := r.removeInstasliceAllocation(ctx, instaslice.Name, &allocation, &allocRequest)
 						if err != nil {
 							return ctrl.Result{}, err
 						}
@@ -264,6 +264,12 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			log.Info("finalizer deleted for succeeded ", "pod", pod.Name)
 		}
+		// If no allocations exist, update metrics with all slots free
+		err = r.updateMetricsAllSlotsFree(ctx, instasliceList)
+		if err != nil {
+			log.Error(err, "Failed to update instaslice metrics to slots free")
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -273,9 +279,9 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// allocation can be in creating or created while the user deletes the pod.
 		for _, instaslice := range instasliceList.Items {
 			for podUuid, allocation := range instaslice.Status.PodAllocationResults {
+				allocRequest := instaslice.Spec.PodAllocationRequests[podUuid]
 				if podUuid == pod.UID && (allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusCreated) {
 					allocation.AllocationStatus.AllocationStatusController = inferencev1alpha1.AllocationStatusDeleting
-					allocRequest := instaslice.Spec.PodAllocationRequests[podUuid]
 					if err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instaslice.Name, &allocation, &allocRequest); err != nil {
 						log.Info("unable to set instaslice to state deleted for ungated", "pod", pod.Name)
 						return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
@@ -283,7 +289,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					return ctrl.Result{}, nil
 				}
 				if podUuid == pod.UID && allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
-					err := r.removeInstasliceAllocation(ctx, instaslice.Name, &allocation)
+					err := r.removeInstasliceAllocation(ctx, instaslice.Name, &allocation, &allocRequest)
 					if err != nil {
 						return ctrl.Result{}, err
 					}
@@ -308,8 +314,8 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			for _, instaslice := range instasliceList.Items {
 				for podUuid, allocation := range instaslice.Status.PodAllocationResults {
 					if podUuid == pod.UID {
+						allocRequest := instaslice.Spec.PodAllocationRequests[podUuid]
 						if allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
-							allocRequest := instaslice.Spec.PodAllocationRequests[podUuid]
 							err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instaslice.Name, &allocation, &allocRequest)
 							if err != nil {
 								return ctrl.Result{}, err
@@ -397,6 +403,10 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				// Sort by Name in ascending order
 				return instasliceList.Items[i].Name < instasliceList.Items[j].Name
 			})
+
+			var successfulAllocRequest *inferencev1alpha1.AllocationRequest
+			var successfulAllocResult *inferencev1alpha1.AllocationResult
+			var instasliceListItemSuccess inferencev1alpha1.Instaslice
 			for _, instaslice := range instasliceList.Items {
 				// find the GPU on the node and the GPU index where the slice can be created
 				allocRequest, allocResult, err := r.findNodeAndDeviceForASlice(ctx, &instaslice, profileName, policy, pod)
@@ -404,15 +414,37 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					continue
 				}
 				podHasNodeAllocation = true
-				if podHasNodeAllocation {
-					err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instaslice.Name, allocResult, allocRequest)
-					if err != nil {
-						return ctrl.Result{Requeue: true}, nil
-					}
-					// allocation was successful
-					return ctrl.Result{}, nil
-				}
+				successfulAllocRequest = allocRequest
+				successfulAllocResult = allocResult
+				instasliceListItemSuccess = instaslice
+				// Break immediately after finding a suitable allocation
+				break
+
 			}
+			if podHasNodeAllocation {
+				err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instasliceListItemSuccess.Name, successfulAllocResult, successfulAllocRequest)
+				if err != nil {
+					return ctrl.Result{Requeue: true}, err
+				}
+				// allocation was successful
+				// Update total processed GPU slices metrics
+				// Check if metrics need processing based on ObservedGeneration
+				if instasliceListItemSuccess.Status.ObservedGeneration < instasliceListItemSuccess.Generation {
+					if err := r.IncrementTotalProcessedGpuSliceMetrics(string(successfulAllocResult.Nodename), successfulAllocResult.GPUUUID, successfulAllocResult.MigPlacement.Size, successfulAllocResult.MigPlacement.Start, successfulAllocRequest.Profile); err != nil {
+						log.Error(err, "Failed to update total processed GPU slices metric", "nodeName", successfulAllocResult.Nodename, "gpuID", successfulAllocResult.GPUUUID)
+						return ctrl.Result{Requeue: true}, err
+					}
+					// Mark as processed by updating ObservedGeneration
+					instasliceListItemSuccess.Status.ObservedGeneration = instasliceListItemSuccess.Generation
+					if err := r.Status().Update(ctx, &instasliceListItemSuccess); err != nil {
+						log.Error(err, "Failed to update Instaslice status after processing metrics", "allocation", successfulAllocRequest)
+						return ctrl.Result{Requeue: true}, err
+					}
+				}
+
+				return ctrl.Result{}, nil
+			}
+
 		}
 
 		// if the cluster does not have suitable node, requeue request
@@ -425,10 +457,16 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	}
 
+	err = r.updateMetrics(ctx, instasliceList)
+	if err != nil {
+		log.Error(err, "Failed to update instaslice metrics")
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 
-// create the DaemonSet object
+// createInstaSliceDaemonSet - create the DaemonSet object
 func (r *InstasliceReconciler) createInstaSliceDaemonSet(namespace string) *appsv1.DaemonSet {
 	emulatorMode := r.Config.EmulatorModeEnable
 	instasliceDaemonsetImage := r.Config.DaemonsetImage
@@ -542,6 +580,7 @@ func (*InstasliceReconciler) extractGpuProfile(instaslice *inferencev1alpha1.Ins
 	return size, discoveredGiprofile, Ciprofileid, Ciengprofileid
 }
 
+// isPodSchedulingGated checks if a pod has a scheduling gate and is actively blocked
 func checkIfPodGatedByInstaSlice(pod *v1.Pod) bool {
 	for _, gate := range pod.Spec.SchedulingGates {
 		if gate.Name == GateName {
@@ -596,10 +635,12 @@ func (r *InstasliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	controllerManager := ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Pod{}).Named("InstaSlice-controller").
 		Watches(&inferencev1alpha1.Instaslice{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
 		Complete(r)
+
+	return controllerManager
 }
 
 func (r *InstasliceReconciler) unGatePod(podUpdate *v1.Pod) *v1.Pod {
@@ -678,15 +719,22 @@ func (l *RightToLeftPolicy) SetAllocationDetails(profileName string, newStart, s
 	return &inferencev1alpha1.AllocationRequest{}
 }
 
-func (r *InstasliceReconciler) removeInstasliceAllocation(ctx context.Context, instasliceName string, allocation *inferencev1alpha1.AllocationResult) error {
-	if allocation.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
+func (r *InstasliceReconciler) removeInstasliceAllocation(ctx context.Context, instasliceName string, allocResult *inferencev1alpha1.AllocationResult, allocRequest *inferencev1alpha1.AllocationRequest) error {
+	log := logr.FromContext(ctx)
+	if allocResult.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
 		err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instasliceName, nil, nil)
 		if err != nil {
 			return err
 		}
 	}
+	// update DeployedPodTotal Metrics by setting value to 0 as pod allocation is deleted
+	if err := r.UpdateDeployedPodTotalMetrics(string(allocResult.Nodename), allocResult.GPUUUID, allocRequest.PodRef.Namespace, allocRequest.PodRef.Name, allocRequest.Profile, 0); err != nil {
+		log.Error(err, "Failed to update deployed pod metrics", "nodeName", allocResult.Nodename)
+		return err
+	}
 	return nil
 }
+
 func (r *InstasliceReconciler) setInstasliceAllocationToDeleting(ctx context.Context, instasliceName string, allocResult *inferencev1alpha1.AllocationResult, allocRequest *inferencev1alpha1.AllocationRequest) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
 	allocResult.AllocationStatus.AllocationStatusController = inferencev1alpha1.AllocationStatusDeleting

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2025.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	logr "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// updateMetrics - updates UpdateDeployedPodTotalMetrics, UpdateGpuSliceMetrics and UpdateCompatibleProfilesMetrics
+func (r *InstasliceReconciler) updateMetrics(ctx context.Context, instasliceList inferencev1alpha1.InstasliceList) error {
+	log := logr.FromContext(ctx)
+	for _, instaslice := range instasliceList.Items {
+		remainingSlotsPerGPU := map[string]int32{}
+
+		// Iterate over GPUs from Status.NodeResources.NodeGPUs
+		for _, gpu := range instaslice.Status.NodeResources.NodeGPUs {
+			nodeName := instaslice.Name
+			gpuID := gpu.GPUUUID // Extract GPU UUID
+
+			// If no allocations exist, update metrics with all slots free
+			if len(instaslice.Spec.PodAllocationRequests) == 0 {
+				totalSlots, err := r.getTotalGpuSlotsForGPU(instaslice, gpuID)
+				if err != nil {
+					log.Error(err, "Failed to determine total GPU slots for GPU without allocations", "gpuID", gpuID)
+					continue
+				}
+				if err := r.UpdateGpuSliceMetrics(nodeName, gpuID, 0, totalSlots); err != nil {
+					log.Error(err, "Failed to update GPU slice metrics for unallocated GPU", "nodeName", nodeName, "gpuID", gpuID)
+				}
+				remainingSlotsPerGPU[gpuID] = totalSlots
+				continue
+			}
+
+			// Check if GPU is present in allocations
+			allocated := false
+			for podUuid, allocation := range instaslice.Status.PodAllocationResults {
+				if allocation.GPUUUID == gpuID {
+					allocRequest := instaslice.Spec.PodAllocationRequests[podUuid]
+					allocated = true
+					nodeName := allocation.Nodename
+					namespace := allocRequest.PodRef.Namespace
+					podname := allocRequest.PodRef.Name
+					profile := allocRequest.Profile
+					usedSlots := calculateUsedSlotsForGPU(instaslice, string(nodeName), gpuID)
+					totalSlots, err := r.getTotalGpuSlotsForGPU(instaslice, gpuID)
+					if err != nil {
+						log.Error(err, "Failed to determine total GPU slots", "nodeName", allocation.Nodename, "gpuID", gpuID)
+						continue
+					}
+					freeSlots := totalSlots - usedSlots
+					// update GpuSliceMetrics
+					if err := r.UpdateGpuSliceMetrics(string(nodeName), gpuID, usedSlots, freeSlots); err != nil {
+						return fmt.Errorf("failed to update GPU slice metrics (nodeName: %s, gpuID: %s): %w", nodeName, gpuID, err)
+					}
+					// update DeployedPodTotalMetrics
+					if err = r.UpdateDeployedPodTotalMetrics(string(nodeName), gpuID, namespace, podname, profile, allocation.MigPlacement.Size); err != nil {
+						return fmt.Errorf("failed to update deployed pod metrics (nodeName: %s): %w", nodeName, err)
+					}
+					remainingSlotsPerGPU[gpuID] = totalSlots - usedSlots
+				}
+			}
+
+			// If GPU is not allocated, set usedSlots to 0 and freeSlots to totalSlots
+			if !allocated {
+				totalSlots, err := r.updateGpuSliceMetricsForUnallocatedGPU(instaslice, nodeName, gpuID)
+				if err != nil {
+					log.Error(err, "Failed to update GPU slice metrics for unallocated GPU", "nodeName", nodeName, "gpuID", gpuID)
+					return err
+				}
+				remainingSlotsPerGPU[gpuID] = totalSlots
+			}
+		}
+		// update CompatibleProfilesMetrics
+		if err := r.UpdateCompatibleProfilesMetrics(instaslice, instaslice.Name, remainingSlotsPerGPU); err != nil {
+			log.Error(err, "Failed to update Compatible Profiles Metrics", "nodeName", instaslice.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// updateMetricsAllSlotsFree - If no allocations exist, update metrics with all slots free
+func (r *InstasliceReconciler) updateMetricsAllSlotsFree(ctx context.Context, instasliceList inferencev1alpha1.InstasliceList) error {
+	log := logr.FromContext(ctx)
+	for _, instaslice := range instasliceList.Items {
+		remainingSlotsPerGPU := map[string]int32{}
+		for _, gpu := range instaslice.Status.NodeResources.NodeGPUs {
+			nodeName := instaslice.Name
+			gpuID := gpu.GPUUUID // Extract GPU UUID
+
+			if len(instaslice.Spec.PodAllocationRequests) == 0 {
+				totalSlots, err := r.updateGpuSliceMetricsForUnallocatedGPU(instaslice, nodeName, gpuID)
+				if err != nil {
+					log.Error(err, "Failed to update GPU slice metrics for unallocated GPU", "nodeName", nodeName, "gpuID", gpuID)
+					return err
+				}
+				remainingSlotsPerGPU[gpuID] = totalSlots
+				continue
+			}
+		}
+		// update CompatibleProfilesMetrics
+		if err := r.UpdateCompatibleProfilesMetrics(instaslice, instaslice.Name, remainingSlotsPerGPU); err != nil {
+			log.Error(err, "Failed to update Compatible Profiles Metrics", "nodeName", instaslice.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// updateGpuSliceMetricsForUnallocatedGPU - Updates GPU metrics when no allocations exist
+func (r *InstasliceReconciler) updateGpuSliceMetricsForUnallocatedGPU(instaslice inferencev1alpha1.Instaslice, nodeName, gpuID string) (int32, error) {
+	totalSlots, err := r.getTotalGpuSlotsForGPU(instaslice, gpuID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to determine total GPU slots for unallocated GPU (gpuID: %s): %w", gpuID, err)
+	}
+	if err := r.UpdateGpuSliceMetrics(nodeName, gpuID, 0, totalSlots); err != nil {
+		return 0, fmt.Errorf("failed to update GPU slice metrics (nodeName: %s, gpuID: %s): %w", nodeName, gpuID, err)
+	}
+	return totalSlots, nil
+}
+
+// Calculates used slots for a specific GPU
+func calculateUsedSlotsForGPU(instaslice inferencev1alpha1.Instaslice, nodeName, gpuID string) int32 {
+	usedSlots := int32(0)
+	for _, allocation := range instaslice.Status.PodAllocationResults {
+		if string(allocation.Nodename) == nodeName && allocation.GPUUUID == gpuID {
+			if string(allocation.Nodename) == nodeName && allocation.GPUUUID == gpuID {
+				if allocation.MigPlacement.Size == 8 { // handle for 7g.40gb profile
+					usedSlots += 7
+				} else if allocation.MigPlacement.Start == 4 && allocation.MigPlacement.Size == 4 { // fills gpu and it doesnt need an extra slice
+					usedSlots += 3
+				} else if allocation.MigPlacement.Start == 6 && allocation.MigPlacement.Size == 2 { // fills gpu and it doesnt need an extra slice
+					usedSlots += 1
+				} else {
+					usedSlots += allocation.MigPlacement.Size
+				}
+			}
+		}
+	}
+	return usedSlots
+}
+
+// Retrieves the total GPU slots available for a specific GPU
+func (r *InstasliceReconciler) getTotalGpuSlotsForGPU(instaslice inferencev1alpha1.Instaslice, gpuID string) (int32, error) {
+	const slotsPerGPU = 7
+	for _, gpu := range instaslice.Status.NodeResources.NodeGPUs {
+		if gpu.GPUUUID == gpuID {
+			return slotsPerGPU, nil
+		}
+	}
+
+	// If GPU ID is not found, return an error
+	return 0, fmt.Errorf("GPU ID %s not found in Instaslice object", gpuID)
+}

--- a/internal/controller/prometheus_manager.go
+++ b/internal/controller/prometheus_manager.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023, 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type InstasliceMetrics struct {
+	GpuSliceTotal      *prometheus.GaugeVec
+	compatibleProfiles *prometheus.GaugeVec
+	processedSlices    *prometheus.GaugeVec
+	deployedPodTotal   *prometheus.GaugeVec
+}
+
+var (
+	instasliceMetrics = &InstasliceMetrics{
+		// Total number of GPU slices
+		GpuSliceTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_gpu_slices_total",
+			Help: "Total number of GPU slices utilized and free per gpu in a node.",
+		},
+			[]string{"node", "gpu_id", "slot_status"}), // Labels: node, GPU ID, slot status.
+		// Current deployed pod total
+		deployedPodTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_current_deployed_pod",
+			Help: "Pods that are currently running with their slice/s usage.",
+		},
+			[]string{"node", "gpu_id", "namespace", "podname", "profile"}), // Labels: node, GPU ID, namespace, podname, profile
+		// compatible profiles with remaining gpu slices
+		compatibleProfiles: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_compatible_profiles",
+			Help: "Profiles compatible with remaining GPU slices in a node and their counts.",
+		},
+			[]string{"profile", "node"}), // Labels: profile, node
+		// total processed slices
+		processedSlices: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_total_processed_gpu_slices",
+			Help: "Number of total processed GPU slices since instaslice controller start time.",
+		},
+			[]string{"node", "gpu_id"}), // Labels: node, GPU ID
+	}
+)
+
+// RegisterMetrics registers all Prometheus metrics
+func RegisterMetrics() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(instasliceMetrics.GpuSliceTotal, instasliceMetrics.compatibleProfiles, instasliceMetrics.processedSlices, instasliceMetrics.deployedPodTotal)
+}
+
+// UpdateGpuSliceMetrics updates GPU slice allocation metrics
+func (r *InstasliceReconciler) IncrementTotalProcessedGpuSliceMetrics(nodeName, gpuID string, processedSlices int32, startPos int32, profile string) error {
+	if processedSlices == 8 { // special handle for 7g.40gb profile
+		processedSlices = 7
+	} else if startPos == 4 && processedSlices == 4 { // fills gpu and it doesnt need an extra slice
+		processedSlices = 3
+	} else if startPos == 6 && processedSlices == 2 { // fills gpu and it doesnt need an extra slice
+		processedSlices = 1
+	}
+	instasliceMetrics.processedSlices.WithLabelValues(
+		nodeName, gpuID).Add(float64(processedSlices))
+	ctrl.Log.Info(fmt.Sprintf("[IncrementTotalProcessedGpuSliceMetrics] Incremented Total Processed GPU Slices: %d total processed slices, for node -> %v, GPUID -> %v.", processedSlices, nodeName, gpuID)) // trace
+	return nil
+}
+
+// UpdateGpuSliceMetrics updates GPU slice allocation metrics
+func (r *InstasliceReconciler) UpdateGpuSliceMetrics(nodeName, gpuID string, usedSlots, freeSlots int32) error {
+	instasliceMetrics.GpuSliceTotal.WithLabelValues(
+		nodeName, gpuID, "used").Set(float64(usedSlots))
+	instasliceMetrics.GpuSliceTotal.WithLabelValues(
+		nodeName, gpuID, "free").Set(float64(freeSlots))
+	ctrl.Log.Info(fmt.Sprintf("[UpdateGpuSliceMetrics] Updated GPU Slices: %d used slot/s, %d freeslot for node -> %v, GPUID -> %v", usedSlots, freeSlots, nodeName, gpuID)) // trace
+	return nil
+}
+
+// UpdateGpuSliceMetrics updates GPU slice allocation metrics
+func (r *InstasliceReconciler) UpdateDeployedPodTotalMetrics(nodeName, gpuID, namespace, podname, profile string, size int32) error {
+	if namespace == "" && podname == "" && profile == "" {
+		return nil
+	}
+	instasliceMetrics.deployedPodTotal.WithLabelValues(
+		nodeName, gpuID, namespace, podname, profile).Set(float64(size))
+	ctrl.Log.Info(fmt.Sprintf("[UpdateDeployedPodTotalMetrics] Updated Deployed Pod: %d used slice/s, for node -> %v, GPUID -> %v, namespace -> %v, podname -> %v, profile -> %v", size, nodeName, gpuID, namespace, podname, profile)) // trace
+	return nil
+}
+
+// UpdateCompatibleProfilesMetrics updates metrics based on remaining GPU slices and calculates compatible profiles dynamically
+func (r *InstasliceReconciler) UpdateCompatibleProfilesMetrics(instasliceObj inferencev1alpha1.Instaslice, nodeName string, remainingSlices map[string]int32) error {
+	// Track currently compatible profiles
+	currentProfiles := make(map[string]int32)
+	sortedGPUs := sortGPUs(&instasliceObj)
+	// Iterate over each profile
+	for profileName, migPlacement := range instasliceObj.Status.NodeResources.MigPlacement {
+		if len(migPlacement.Placements) > 0 {
+			size := migPlacement.Placements[0].Size
+			totalFit := int32(0)
+			// Iterate over all GPUs
+			for _, gpuID := range sortedGPUs {
+				totalFit += r.getTotalFitForProfileOnGPU(&instasliceObj, profileName, size, remainingSlices[gpuID])
+			}
+			currentProfiles[profileName] = totalFit
+
+		}
+	}
+	// Update Prometheus metrics
+	for profileName, totalFit := range currentProfiles {
+		instasliceMetrics.compatibleProfiles.WithLabelValues(profileName, nodeName).
+			Set(float64(totalFit))
+		ctrl.Log.Info("[UpdateCompatibleProfilesMetrics] Updated compatible profile", "profile", profileName, "count", totalFit)
+	}
+
+	return nil
+}

--- a/internal/controller/prometheus_manager_test.go
+++ b/internal/controller/prometheus_manager_test.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Instaslice Controller", func() {
+	var (
+		fakeClient client.Client
+		r          *InstasliceReconciler
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		Expect(inferencev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(v1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		r = &InstasliceReconciler{
+			Client: fakeClient,
+		}
+	})
+
+	// Test IncrementTotalProcessedGpuSliceMetrics
+	It("should increment total processed GPU slice metrics", func() {
+		err := r.IncrementTotalProcessedGpuSliceMetrics("node-1", "gpu-1", 4, 0, "1g.5gb")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Test UpdateGpuSliceMetrics
+	It("should update GPU slice metrics", func() {
+		err := r.UpdateGpuSliceMetrics("node-1", "gpu-1", 3, 5)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Test UpdateDeployedPodTotalMetrics
+	It("should update deployed pod total metrics", func() {
+		err := r.UpdateDeployedPodTotalMetrics("node-1", "gpu-1", "namespace-1", "pod-1", "profile-1", 2)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Test UpdateCompatibleProfilesMetrics
+	It("should update compatible profiles metrics", func() {
+		instaslice := inferencev1alpha1.Instaslice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "instaslice-1",
+				Namespace: "default",
+			},
+		}
+		err := r.UpdateCompatibleProfilesMetrics(instaslice, "node-1", map[string]int32{"gpu-1": 6})
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Addresses - https://github.com/openshift/instaslice-operator/issues/53
Enable Kubernetes metrics from controllers
And add Custom metrics
- _instaslice_gpu_slices_total_ : Total number of GPU slices utilized and free per gpu in a node
- _instaslice_current_deployed_pod_: Pods that are currently running with their slice/s usage
- _instaslice_compatible_profiles_: Profiles compatible with remaining GPU slices in a node and their counts
- _instaslice_total_processed_gpu_slices_ : Number of total processed GPU slices since instaslice controller start time

- [x] Unit tests added for metrics reconcile funcs and calls in instaslice _controller and prometheus_manager

**Updated**: Successful run of make test, make lint, make test-e2e, and make test-e2e-kind-emulated
