### PR TITLE
Fetch the GPU memory from the `nvml` lib api

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -23,6 +23,8 @@ const (
 	GateName                         = OrgInstaslicePrefix + "accelerator"
 	FinalizerName                    = GateName
 	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
+	GPUMemoryLabelName               = "nvidia.com/gpu.memory"
+	GPUCountLabelName                = "nvidia.com/gpu.count"
 	EmulatorModeFalse                = "false"
 	EmulatorModeTrue                 = "true"
 	AttributeMediaExtensions         = "me"


### PR DESCRIPTION
- Modified the code to use `nvml` library's API call to fetch the GPU memory info before patching the node capacity
- However, the old code has been retained to leverage it during the emulated scenario

`make test, make test-e2e-kind-emulated, make lint` pass locally

~/hold
Until the code is tested on the GPU~

Performed e2e tests on the real GPU