### PR TITLE
separate image references to eliminate conflict.

### DIFF
--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -210,10 +210,10 @@ spec:
                 command:
                 - /manager
                 env:
-                - name: EMULATOR_MODE
-                  value: "false"
                 - name: RELATED_IMAGE_INSTASLICE_DAEMONSET
                   value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:4e0529d6b1e3801156f163fee089b99d8be6036ff7b2ef0bd47e0dc9957c3eb3
+                - name: EMULATOR_MODE
+                  value: "false"
                 image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:12007f0366a8d4ecaead4717cec16d90dcaf335d7158b78c0cf50bd4fd48cd3e
                 livenessProbe:
                   httpGet:


### PR DESCRIPTION
Per konflux team's suggestion, separating the two image references will eliminate the conflicts we get for the two nudge PRs.