### PR TITLE
Decouple e2e invocation in ocp from operator installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ test-e2e-ocp-emulated: export EMULATOR_MODE=true
 test-e2e-ocp-emulated: check-gpu-nodes docker-build docker-push deploy-instaslice-emulated-on-ocp
 test-e2e-ocp-emulated:
 	$(eval FOCUS_ARG := $(if $(FOCUS),--focus="$(FOCUS)"))
-	export KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
 	ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m $(FOCUS_ARG) ./test/e2e
 
 PHONY: cleanup-test-e2e-ocp-emulated
@@ -180,12 +179,9 @@ cleanup-test-e2e-ocp-emulated: KUBECTL=oc
 cleanup-test-e2e-ocp-emulated: ocp-undeploy-emulated
 
 .PHONY: test-e2e-ocp
-test-e2e-ocp: export IMG_TAG=latest
-test-e2e-ocp: export EMULATOR_MODE=false
-test-e2e-ocp: docker-build docker-push ocp-deploy wait-for-instaslice-operator-stable
+test-e2e-ocp: wait-for-instaslice-operator-stable
 test-e2e-ocp:
 	$(eval FOCUS_ARG := $(if $(FOCUS),--focus="$(FOCUS)"))
-	export KUBECTL=oc IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
 	ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m $(FOCUS_ARG) ./test/e2e
 
 PHONY: cleanup-test-e2e-ocp


### PR DESCRIPTION
Following on the [footsteps of cert-manager-operator](https://github.com/openshift/cert-manager-operator/blob/6fbe83159f4b7b5f886462c0b198242b4c3b1711/Makefile#L244), this PR decouples operator installation from the e2e invocation. This helps outsourcing operator installation to external entities (like `prow`) and `test-e2e-ocp` only used for invoking the tests. 

