### PR TITLE
fix base files and regenerate bundle-ocp and dockerfile

### DIFF
--- a/.tekton/integration-tests/deploy-operator.yaml
+++ b/.tekton/integration-tests/deploy-operator.yaml
@@ -163,12 +163,12 @@ spec:
                 name: openshift-cert-manager-operator
                 namespace: cert-manager-operator
               spec:
-                channel: stable-v1
+                channel: stable-v1.14
                 name: openshift-cert-manager-operator
                 source: redhat-operators
                 sourceNamespace: openshift-marketplace
                 installPlanApproval: Automatic
-                startingCSV: cert-manager-operator.v1.13.0
+                startingCSV: cert-manager-operator.v1.14.1
               EOF
               # create namespace for operator
               oc new-project instaslice-system

--- a/bundle-ocp.Dockerfile
+++ b/bundle-ocp.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=instaslice-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle-ocp/manifests/controller-manager_v1_serviceaccount.yaml
+++ b/bundle-ocp/manifests/controller-manager_v1_serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: instaslice-operator
+  name: controller-manager

--- a/bundle-ocp/manifests/instaslice-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle-ocp/manifests/instaslice-operator-controller-manager-metrics-service_v1_service.yaml
@@ -15,7 +15,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   selector:
     control-plane: controller-manager
 status:

--- a/bundle-ocp/manifests/instaslice-operator-scc_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-ocp/manifests/instaslice-operator-scc_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,6 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: instaslice-operator-scc
 rules:
 - apiGroups:

--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -25,22 +25,22 @@ metadata:
     containerImage: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:19f0baa4a6d3a0e126e054b4341788fd99f125a6f68224661d21294c95873aa6
     createdAt: "2024-11-01T14:26:33Z"
     description: InstaSlice works with GPU operator to create mig slices on demand
-    operators.operatorframework.io/builder: operator-sdk-v1.34.2
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "false"
-    features.operators.openshift.io/csi: "false"
-    features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
-    features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/cnf: "false"		
+    features.operators.openshift.io/cni: "false"		
+    features.operators.openshift.io/csi: "false"		
+    features.operators.openshift.io/disconnected: "true"		
+    features.operators.openshift.io/fips-compliant: "false"		
+    features.operators.openshift.io/proxy-aware: "false"		
+    features.operators.openshift.io/tls-profiles: "false"		
+    features.operators.openshift.io/token-auth-aws: "false"		
+    features.operators.openshift.io/token-auth-azure: "false"		
+    features.operators.openshift.io/token-auth-gcp: "false"		
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     repository: https://github.com/openshift/instaslice-operator
     support: https://github.com/openshift/instaslice-operator/issues
-  name: instaslice-operator.v0.1.0
+  name: instaslice-operator.v0.0.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -49,9 +49,9 @@ spec:
     - kind: Instaslice
       name: instaslices.inference.redhat.com
       version: v1alpha1
-  description: "### Introduction\nInstaSlice works with GPU operator to create mig
-    slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA GPU drivers and
-    CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation)
+  description: "### Introduction\nInstaSlice uses stable APIs and works with GPU operator
+    to create mig slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA
+    GPU drivers and CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation)
     on the host.\n2. Install the [NVIDIA Container Toolkit (CTK)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).\n3.
     Configure the NVIDIA Container Runtime as the default Docker runtime:\n      `sudo
     nvidia-ctk runtime configure --runtime=docker --set-as-default`\n4. Restart Docker
@@ -78,9 +78,23 @@ spec:
     `0.1.0` by\nfollowing [uninstall operator section](https://github.com/openshift/instaslice-operator)\nand
     install the new version.\n\nChanges to patch version (major.minor.patch) indicates
     that no breaking changes\nare introduced, thus upgrade can be done without uninstalling
-    and reinstalling\nthe operator.\n\n### Documentation\nDocumentation and installation
-    guide can be found below:\n  * [Installation Guide](https://github.com/openshift/instaslice-operator)\n
-    \ * [Instaslice Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n###
+    and reinstalling\nthe operator.\n\n### Why Instaslice\n\nPartitionable accelerators
+    provided by vendors need partition to be created at node boot-time or to change
+    partitions one would have to evict all the workloads at the node level to create
+    new set of partitions.\n\nInstaSlice will help if:\n\n- user does not know all
+    the accelerators partitions needed a priori on every node on the cluster\n\n-
+    user partition requirements change at the workload level rather than the node
+    level\n\n- user does not want to learn or use new API to request accelerators
+    slices\n\n- user prefers to use stable device plugins APIs for creating partitions\n\n###Features
+    Overview\n\n- Integration with Kubernetes [quota management](https://github.com/openshift/instaslice-operator/blob/main/docs/instaslice_kube_quota_int.md)\n\n-
+    Integration with project [Kueue](https://github.com/openshift/instaslice-operator/blob/main/docs/kueue.md)\n\n-
+    [Emulator](https://github.com/openshift/instaslice-operator/blob/main/docs/emulator.md)
+    mode to run test InstaSlice firstfit placement strategy\n\n- Integration with
+    vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml),
+    [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml),
+    and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n###
+    Documentation\nDocumentation and installation guide can be found below:\n  * [Installation
+    Guide](https://github.com/openshift/instaslice-operator)\n  * [Instaslice Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n###
     License\ninstaslice-operator is licensed under the Apache 2.0 license"
   displayName: Instaslice
   icon:
@@ -158,6 +172,102 @@ spec:
           - get
           - patch
           - update
+        - nonResourceURLs:
+          - /metrics
+          verbs:
+          - get
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - instaslice-operator-scc
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - inference.redhat.com
+          resources:
+          - instaslices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - inference.redhat.com
+          resources:
+          - instaslices/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - inference.redhat.com
+          resources:
+          - instaslices/status
+          verbs:
+          - get
+          - patch
+          - update
+        - nonResourceURLs:
+          - /metrics
+          verbs:
+          - get
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -205,7 +315,7 @@ spec:
               containers:
               - args:
                 - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=:8443
                 - --leader-elect
                 command:
                 - /manager
@@ -311,8 +421,24 @@ spec:
   maintainers:
   - email: amalvank@redhat.com
     name: Abhishek Malvankar
+  - email: cmeadors@redhat.com
+    name: Cameron Meadors
+  - email: harpatil@redhat.com
+    name: Harshal Patil
+  - email: kehannon@redhat.com
+    name: Kevin Hannon
   - email: mmunirab@redhat.com
     name: Mohammed Abdi
+  - email: mpatel@redhat.com
+    name: Mrunal Patel
+  - email: tardieu@us.ibm.com
+    name: Olivier Tardieu
+  - email: rphillip@redhat.com
+    name: Ryan Phillips
+  - email: svanka@redhat.com
+    name: Sai Ramesh Vanka
+  - email: vemporop@redhat.com
+    name: Vitaliy Emporopulo
   maturity: alpha
   minKubeVersion: 1.16.0
   provider:
@@ -321,7 +447,7 @@ spec:
   relatedImages:
   - image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:04dd785a51aaa94888c724c395f7e8dba1ae5f1103a9aa505e9ec7bf5ca03b60
     name: instaslice-daemonset
-  version: 0.1.0
+  version: 0.0.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle-ocp/manifests/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle-ocp/manifests/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: instaslice-operator
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/bundle-ocp/manifests/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle-ocp/manifests/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: instaslice-operator
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/bundle-ocp/manifests/manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-ocp/manifests/manager-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,74 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - inference.redhat.com
+  resources:
+  - instaslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.redhat.com
+  resources:
+  - instaslices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - inference.redhat.com
+  resources:
+  - instaslices/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/bundle-ocp/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-ocp/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: instaslice-operator
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle-ocp/manifests/proxy-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-ocp/manifests/proxy-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/created-by: instaslice-operator
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: instaslice-operator
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,14 +57,14 @@ spec:
       #             values:
       #               - linux
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/config/manifests-ocp-emulated/kustomization.yaml
+++ b/config/manifests-ocp-emulated/kustomization.yaml
@@ -3,6 +3,7 @@
 resources:
 - bases/instaslice-operator.clusterserviceversion.yaml
 - ../ocp-emulated
+- ../rbac-ocp
 - ../samples
 - ../scorecard
 

--- a/config/manifests-ocp/kustomization.yaml
+++ b/config/manifests-ocp/kustomization.yaml
@@ -3,6 +3,7 @@
 resources:
 - bases/instaslice-operator.clusterserviceversion.yaml
 - ../ocp
+- ../rbac-ocp
 - ../samples
 - ../scorecard
 

--- a/config/rbac-ocp/openshift_scc_cluster_role_binding.yaml
+++ b/config/rbac-ocp/openshift_scc_cluster_role_binding.yaml
@@ -8,5 +8,5 @@ subjects:
   namespace: instaslice-system
 roleRef:
   kind: ClusterRole
-  name: system:openshift:scc:instaslice-operator-scc
+  name: instaslice-operator-scc
   apiGroup: rbac.authorization.k8s.io

--- a/hack/manifests/cert-manager-rh.yaml
+++ b/hack/manifests/cert-manager-rh.yaml
@@ -20,10 +20,10 @@ metadata:
   name: openshift-cert-manager-operator
   namespace: cert-manager-operator
 spec:
-  channel: stable-v1
+  channel: stable-v1.14
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
-  startingCSV: cert-manager-operator.v1.13.0
+  startingCSV: cert-manager-operator.v1.14.1
 


### PR DESCRIPTION
this catches up the generated bundle for ocp with the code.
Include version bumps for cert-manager deployment scripts