### PR TITLE
Fix Cert manager version

### DIFF
--- a/.tekton/integration-tests/deploy-operator.yaml
+++ b/.tekton/integration-tests/deploy-operator.yaml
@@ -163,12 +163,12 @@ spec:
                 name: openshift-cert-manager-operator
                 namespace: cert-manager-operator
               spec:
-                channel: stable-v1
+                channel: stable-v1.14
                 name: openshift-cert-manager-operator
                 source: redhat-operators
                 sourceNamespace: openshift-marketplace
                 installPlanApproval: Automatic
-                startingCSV: cert-manager-operator.v1.13.0
+                startingCSV: cert-manager-operator.v1.14.1
               EOF
               # create namespace for operator
               oc new-project instaslice-system

--- a/bundle-ocp.Dockerfile
+++ b/bundle-ocp.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=instaslice-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle-ocp/manifests/instaslice-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle-ocp/manifests/instaslice-operator-controller-manager-metrics-service_v1_service.yaml
@@ -15,7 +15,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   selector:
     control-plane: controller-manager
 status:

--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     containerImage: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:0600fe10ed25bd9e4d6be586b6d92e69fb85a23252cddf8e3f2fda3fe0736a8f
     createdAt: "2024-11-01T14:26:33Z"
     description: InstaSlice works with GPU operator to create mig slices on demand
-    operators.operatorframework.io/builder: operator-sdk-v1.34.2
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -40,7 +40,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     repository: https://github.com/openshift/instaslice-operator
     support: https://github.com/openshift/instaslice-operator/issues
-  name: instaslice-operator.v0.1.0
+  name: instaslice-operator.v0.0.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -49,9 +49,9 @@ spec:
     - kind: Instaslice
       name: instaslices.inference.redhat.com
       version: v1alpha1
-  description: "### Introduction\nInstaSlice works with GPU operator to create mig
-    slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA GPU drivers and
-    CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation)
+  description: "### Introduction\nInstaSlice uses stable APIs and works with GPU operator
+    to create mig slices on demand.\n\n### Prerequisites\n\n1. Install the [NVIDIA
+    GPU drivers and CUDA toolkit](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#driver-installation)
     on the host.\n2. Install the [NVIDIA Container Toolkit (CTK)](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).\n3.
     Configure the NVIDIA Container Runtime as the default Docker runtime:\n      `sudo
     nvidia-ctk runtime configure --runtime=docker --set-as-default`\n4. Restart Docker
@@ -78,9 +78,23 @@ spec:
     `0.1.0` by\nfollowing [uninstall operator section](https://github.com/openshift/instaslice-operator)\nand
     install the new version.\n\nChanges to patch version (major.minor.patch) indicates
     that no breaking changes\nare introduced, thus upgrade can be done without uninstalling
-    and reinstalling\nthe operator.\n\n### Documentation\nDocumentation and installation
-    guide can be found below:\n  * [Installation Guide](https://github.com/openshift/instaslice-operator)\n
-    \ * [Instaslice Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n###
+    and reinstalling\nthe operator.\n\n### Why Instaslice\n\nPartitionable accelerators
+    provided by vendors need partition to be created at node boot-time or to change
+    partitions one would have to evict all the workloads at the node level to create
+    new set of partitions.\n\nInstaSlice will help if:\n\n- user does not know all
+    the accelerators partitions needed a priori on every node on the cluster\n\n-
+    user partition requirements change at the workload level rather than the node
+    level\n\n- user does not want to learn or use new API to request accelerators
+    slices\n\n- user prefers to use stable device plugins APIs for creating partitions\n\n###Features
+    Overview\n\n- Integration with Kubernetes [quota management](https://github.com/openshift/instaslice-operator/blob/main/docs/instaslice_kube_quota_int.md)\n\n-
+    Integration with project [Kueue](https://github.com/openshift/instaslice-operator/blob/main/docs/kueue.md)\n\n-
+    [Emulator](https://github.com/openshift/instaslice-operator/blob/main/docs/emulator.md)
+    mode to run test InstaSlice firstfit placement strategy\n\n- Integration with
+    vLLM, Kserve, [Deployments](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_deployment.yaml),
+    [Jobs](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_job.yaml),
+    and [Statefulsets](https://github.com/openshift/instaslice-operator/blob/main/samples/vllm_statefulset.yaml)\n\n###
+    Documentation\nDocumentation and installation guide can be found below:\n  * [Installation
+    Guide](https://github.com/openshift/instaslice-operator)\n  * [Instaslice Operator](https://github.com/openshift/instaslice-operator/blob/main/README.md)\n\n###
     License\ninstaslice-operator is licensed under the Apache 2.0 license"
   displayName: Instaslice
   icon:
@@ -158,6 +172,10 @@ spec:
           - get
           - patch
           - update
+        - nonResourceURLs:
+          - /metrics
+          verbs:
+          - get
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -205,7 +223,7 @@ spec:
               containers:
               - args:
                 - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=:8443
                 - --leader-elect
                 command:
                 - /manager
@@ -311,8 +329,24 @@ spec:
   maintainers:
   - email: amalvank@redhat.com
     name: Abhishek Malvankar
+  - email: cmeadors@redhat.com
+    name: Cameron Meadors
+  - email: harpatil@redhat.com
+    name: Harshal Patil
+  - email: kehannon@redhat.com
+    name: Kevin Hannon
   - email: mmunirab@redhat.com
     name: Mohammed Abdi
+  - email: mpatel@redhat.com
+    name: Mrunal Patel
+  - email: tardieu@us.ibm.com
+    name: Olivier Tardieu
+  - email: rphillip@redhat.com
+    name: Ryan Phillips
+  - email: svanka@redhat.com
+    name: Sai Ramesh Vanka
+  - email: vemporop@redhat.com
+    name: Vitaliy Emporopulo
   maturity: alpha
   minKubeVersion: 1.16.0
   provider:
@@ -321,7 +355,7 @@ spec:
   relatedImages:
   - image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:cbb3e7dc15c9a830df94aea421b611ff198f6ca4f46a9188624e80553f01071b
     name: instaslice-daemonset
-  version: 0.1.0
+  version: 0.0.2
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,14 +57,14 @@ spec:
       #             values:
       #               - linux
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/hack/manifests/cert-manager-rh.yaml
+++ b/hack/manifests/cert-manager-rh.yaml
@@ -20,10 +20,10 @@ metadata:
   name: openshift-cert-manager-operator
   namespace: cert-manager-operator
 spec:
-  channel: stable-v1
+  channel: stable-v1.14
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
-  startingCSV: cert-manager-operator.v1.13.0
+  startingCSV: cert-manager-operator.v1.14.1
 


### PR DESCRIPTION
With this fix the openshift cert manager operator comes up fine when deployed using `make test-e2e-ocp-emulated`

```bash
harshal@fedora:~/go/src/github.com/openshift/instaslice-operator$ oc get pods -n cert-manager-operator 
NAME                                                        READY   STATUS    RESTARTS   AGE
cert-manager-operator-controller-manager-5f75966664-vmscp   2/2     Running   0          7m26s
harshal@fedora:~/go/src/github.com/openshift/instaslice-operator$ oc get pods -n cert-manager
NAME                                      READY   STATUS    RESTARTS   AGE
cert-manager-7f8467d8d4-rx9wx             1/1     Running   0          6m32s
cert-manager-cainjector-cf99769f9-rnsxc   1/1     Running   0          7m9s
cert-manager-webhook-849bf8759b-2nr6n     1/1     Running   0          7m10s
harshal@fedora:~/go/src/github.com/openshift/instaslice-operator$ 
```