### PR TITLE
add tasks to deploy-operator pipeline to run e2e tests

### DIFF
--- a/.tekton/integration-tests/deploy-operator.yaml
+++ b/.tekton/integration-tests/deploy-operator.yaml
@@ -224,3 +224,50 @@ spec:
               - --namespace
               - "$(params.namespace)"
               - "$(params.bundleImage)"
+    - name: e2e-tests
+      runAfter:
+        - deploy-operator
+      taskSpec:
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.provision-eaas-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-tests
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: registry.redhat.io/rhel9/go-toolset:1.22.5
+            script: |
+              # git clone https://github.com/cpmeadors/instaslice-operator # for testing
+              git clone https://github.com/openshift/instaslice-operator
+              curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.17/openshift-client-linux-amd64-rhel9.tar.gz \
+                && tar -xvzf oc.tar.gz \
+                && chmod +x kubectl oc \
+                && mkdir ~/bin \
+                && mv oc kubectl ~/bin/
+              export PATH=$PATH:~/bin:~/go/bin
+              cd instaslice-operator
+              # git checkout e2e-test-steps # for testing
+              go install github.com/onsi/ginkgo/v2/ginkgo
+              go get github.com/onsi/gomega/...
+              make test-e2e-konflux

--- a/bundle-ocp/manifests/inference.redhat.com_instaslices.yaml
+++ b/bundle-ocp/manifests/inference.redhat.com_instaslices.yaml
@@ -38,17 +38,17 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstasliceSpec defines the desired state of Instaslice
+            description: |-
+              spec defines the current state of different allocations in the Instaslice resource.
+              It contains configuration details, such as GPU allocation settings,
+              node-specific parameters, and placement preferences.
             properties:
-              MigGPUUUID:
-                additionalProperties:
-                  type: string
-                type: object
               allocations:
                 additionalProperties:
                   description: Define the struct for allocation details
                   properties:
                     allocationStatus:
+                      description: allocationStatus represents status of allocation
                       enum:
                       - deleted
                       - deleting
@@ -57,29 +57,43 @@ spec:
                       - created
                       type: string
                     cpu:
+                      description: cpu represents amount of cpu requested by user
+                        workload
                       format: int64
                       type: integer
                     gpuUUID:
+                      description: gpuUUID represents gpu uuid of selected gpu
                       type: string
                     memory:
+                      description: memory represents amount of memory requested by
+                        user workload
                       format: int64
                       type: integer
                     namespace:
+                      description: namespace represents namespace of user workload
                       type: string
                     nodename:
+                      description: nodename represents name of the selected node
                       type: string
                     podName:
+                      description: podName represents name of the user workload pod
                       type: string
                     podUUID:
+                      description: podUUID represents uuid of user workload
                       type: string
                     profile:
+                      description: profile requested by user workload
                       type: string
                     resourceIdentifier:
+                      description: resourceIdentifier represents uuid used for creating
+                        configmap resource
                       type: string
                     size:
+                      description: size of profile that begins from start position
                       format: int32
                       type: integer
                     start:
+                      description: start position of a profile on a gpu
                       format: int32
                       type: integer
                   required:
@@ -96,28 +110,55 @@ spec:
                   - size
                   - start
                   type: object
+                description: allocations represents allocation details of user workloads
                 type: object
               cpuonnodeatboot:
+                description: cpuonnodeatboot represents total amount of cpu present
+                  on the node
                 format: int64
                 type: integer
               memoryonnodeatboot:
+                description: memoryonnodeatboot represents total amount of memory
+                  present on the node
                 format: int64
                 type: integer
+              migGpuUuid:
+                additionalProperties:
+                  type: string
+                description: migGpuUuid represents uuid of the mig device created
+                  on the gpu
+                type: object
               migplacement:
+                description: migplacement represents gpu instance, compute instance
+                  with placement for a profile
                 items:
                   properties:
-                    ciProfileid:
-                      type: integer
                     ciengprofileid:
+                      description: ciengprofileid provides compute instance engineering
+                        id of a profile
+                      format: int32
+                      type: integer
+                    ciprofileid:
+                      description: ciprofileid provides compute instance id of a profile
+                      format: int32
                       type: integer
                     giprofileid:
+                      description: giprofileid provides gpu instance id of a profile
+                      format: int32
                       type: integer
                     placements:
+                      description: placements provide vendor profile indexes and sizes
                       items:
                         properties:
                           size:
+                            description: size represents solts consumed by a profile
+                              on gpu
+                            format: int32
                             type: integer
                           start:
+                            description: start represents the begin index driven by
+                              size for a profile
+                            format: int32
                             type: integer
                         required:
                         - size
@@ -125,20 +166,36 @@ spec:
                         type: object
                       type: array
                     profile:
+                      description: profile provides name of the vendor profile
                       type: string
                   required:
-                  - ciProfileid
-                  - ciengprofileid
+                  - ciprofileid
                   - giprofileid
+                  - placements
+                  - profile
                   type: object
                 type: array
+            required:
+            - cpuonnodeatboot
+            - memoryonnodeatboot
+            - migGpuUuid
+            - migplacement
             type: object
           status:
-            description: InstasliceStatus defines the observed state of Instaslice
+            description: |-
+              status represents the observed state of the Instaslice resource.
+              It provides runtime information about the resource, such as whether
+              allocations have been processed.
             properties:
               processed:
+                description: processed represents state of the instaslice object after
+                  daemonset creation
                 type: boolean
+            required:
+            - processed
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -353,7 +353,7 @@ spec:
                 - name: RELATED_IMAGE_INSTASLICE_DAEMONSET
                   value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:b9e9be344a98dcc4aa512b80a21c3b3bcf573aea0ee85c57528a67f445486820
                 - name: EMULATOR_MODE
-                  value: "false"
+                  value: "true"
                 image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:9011485d2980fc825c99bc8edc47ed1873fe2d8041a1b47b1619da951375d2e4
                 imagePullPolicy: Always
                 livenessProbe:

--- a/hack/emulator_mode-patch.json
+++ b/hack/emulator_mode-patch.json
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "replace",
+        "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/1/value",
+        "value": "true"
+    }
+]


### PR DESCRIPTION
Run e2e tests on OCP with emulated mode.  Using the test-for-pr404 integration test in konflux for testing.

Testable by running make test-e2e-konflux against a cluster with cert-manager and instaslice operators installed (EMULATOR_MODE: false).  If you need to retest, remove nvidia labels from all nodes and reinstall the operator (oc delete ns/instaslice-system; make deploy-instaslice-on-ocp)

https://console.redhat.com/application-pipeline/workspaces/dynamicacceleratorsl/applications/dynamicacceleratorslicer/integrationtests/test-for-pr404/pipelineruns