### PR TITLE
aggregate update and delete calls with cleanup

### DIFF
--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -174,7 +174,7 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 			}
 
 			allocations.Allocationstatus = inferencev1alpha1.AllocationStatusDeleted
-			err := utils.UpdateInstasliceAllocations(ctx, r.Client, instaslice.Name, allocations.PodUUID, allocations)
+			err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instaslice.Name, &allocations)
 			if err != nil {
 				log.Error(err, "error updating InstaSlice object for ", "pod", allocations.PodName)
 				return ctrl.Result{Requeue: true}, nil
@@ -273,7 +273,7 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 
 			if updatedAllocation, ok := updateInstasliceObject.Spec.Allocations[allocations.PodUUID]; ok {
 				updatedAllocation.Allocationstatus = inferencev1alpha1.AllocationStatusCreated
-				if err := utils.UpdateInstasliceAllocations(ctx, r.Client, instaslice.Name, updatedAllocation.PodUUID, updatedAllocation); err != nil {
+				if err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instaslice.Name, &updatedAllocation); err != nil {
 					return ctrl.Result{Requeue: true}, nil
 				}
 				return ctrl.Result{}, nil
@@ -328,7 +328,7 @@ func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allo
 			}
 			log.Info("successfully destroyed GPU Instance", "GpuInstanceId", migdevice.giInfo.Id)
 
-			log.Info("deleted ci and gi for", "pod", allocation.PodName, logMigInfosSingleLine(migInfos))
+			log.Info("deleted ci and gi for", "pod", "miginfos", allocation.PodName, logMigInfosSingleLine(migInfos))
 			return nil
 
 		}

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -38,6 +38,7 @@ import (
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
 	"github.com/openshift/instaslice-operator/internal/controller/config"
+	"github.com/openshift/instaslice-operator/internal/controller/utils"
 )
 
 func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
@@ -111,11 +112,9 @@ func TestChangesAllocationDeletionAndFinalizer(t *testing.T) {
 				Allocationstatus: inferencev1alpha1.AllocationStatusDeleted,
 			}
 			Expect(fakeClient.Update(ctx, instaslice)).To(Succeed())
-
-			result, err := r.deleteInstasliceAllocation(ctx, instaslice.Name, instaslice.Spec.Allocations[podUUID])
+			err := utils.UpdateOrDeleteInstasliceAllocations(ctx, r.Client, instaslice.Name, nil)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(ctrl.Result{}))
 
 			updatedInstaSlice := &inferencev1alpha1.Instaslice{}
 			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: instaslice.Name, Namespace: InstaSliceOperatorNamespace}, updatedInstaSlice)).To(Succeed())

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,5 +1,0 @@
-package controller
-
-func AppendToInstaSlicePrefix(suffix string) string {
-	return OrgInstaslicePrefix + suffix
-}


### PR DESCRIPTION
The codebase used almost duplicate update and delete calls in two different files, which is now unified. Removed unused utils.go file.

make test, make lint, and make test-e2e pass on kind cluster.