### PR TITLE
Revert "fix for kal linter (#400)"

### DIFF
--- a/api/v1alpha1/instaslice_types.go
+++ b/api/v1alpha1/instaslice_types.go
@@ -21,30 +21,16 @@ import (
 )
 
 type Mig struct {
-	// placements provide vendor profile indexes and sizes
-	// +required
-	Placements []Placement `json:"placements"`
-	// profile provides name of the vendor profile
-	// +required
-	Profile string `json:"profile"`
-	// giprofileid provides gpu instance id of a profile
-	// +required
-	GIprofileid int32 `json:"giprofileid"`
-	// ciprofileid provides compute instance id of a profile
-	// +required
-	CIProfileID int32 `json:"ciprofileid"`
-	// ciengprofileid provides compute instance engineering id of a profile
-	// +optional
-	CIEngProfileID int32 `json:"ciengprofileid"`
+	Placements     []Placement `json:"placements,omitempty"`
+	Profile        string      `json:"profile,omitempty"`
+	Giprofileid    int         `json:"giprofileid"`
+	CIProfileID    int         `json:"ciProfileid"`
+	CIEngProfileID int         `json:"ciengprofileid"`
 }
 
 type Placement struct {
-	// size represents solts consumed by a profile on gpu
-	// +required
-	Size int32 `json:"size"`
-	// start represents the begin index driven by size for a profile
-	// +required
-	Start int32 `json:"start"`
+	Size  int `json:"size"`
+	Start int `json:"start"`
 }
 type AllocationStatus string
 
@@ -58,69 +44,33 @@ const (
 
 // Define the struct for allocation details
 type AllocationDetails struct {
-	// profile requested by user workload
-	// +required
-	Profile string `json:"profile"`
-	// start position of a profile on a gpu
-	// +required
-	Start int32 `json:"start"`
-	// size of profile that begins from start position
-	// +required
-	Size int32 `json:"size"`
-	// podUUID represents uuid of user workload
-	// +required
-	PodUUID string `json:"podUUID"`
-	// gpuUUID represents gpu uuid of selected gpu
-	// +required
-	GPUUUID string `json:"gpuUUID"`
-	// nodename represents name of the selected node
-	// +required
+	Profile  string `json:"profile"`
+	Start    uint32 `json:"start"`
+	Size     uint32 `json:"size"`
+	PodUUID  string `json:"podUUID"`
+	GPUUUID  string `json:"gpuUUID"`
 	Nodename string `json:"nodename"`
-	// allocationStatus represents status of allocation
 	// +kubebuilder:validation:Enum:=deleted;deleting;ungated;creating;created
-	// +required
-	Allocationstatus AllocationStatus `json:"allocationStatus"`
-	// resourceIdentifier represents uuid used for creating configmap resource
-	// +required
-	Resourceidentifier string `json:"resourceIdentifier"`
-	// namespace represents namespace of user workload
-	// +required
-	Namespace string `json:"namespace"`
-	// podName represents name of the user workload pod
-	// +required
-	PodName string `json:"podName"`
-	// cpu represents amount of cpu requested by user workload
-	// +required
-	Cpu int64 `json:"cpu"`
-	// memory represents amount of memory requested by user workload
-	// +required
-	Memory int64 `json:"memory"`
+	Allocationstatus   AllocationStatus `json:"allocationStatus"`
+	Resourceidentifier string           `json:"resourceIdentifier"`
+	Namespace          string           `json:"namespace"`
+	PodName            string           `json:"podName"`
+	Cpu                int64            `json:"cpu"`
+	Memory             int64            `json:"memory"`
 }
 
 // InstasliceSpec defines the desired state of Instaslice
 type InstasliceSpec struct {
-	// migGpuUuid represents uuid of the mig device created on the gpu
-	// +required
-	MigGPUUUID map[string]string `json:"migGpuUuid"`
-	// allocations represents allocation details of user workloads
-	// +optional
-	Allocations map[string]AllocationDetails `json:"allocations"`
-	// migplacement represents gpu instance, compute instance with placement for a profile
-	// +required
-	Migplacement []Mig `json:"migplacement"`
-	// cpuonnodeatboot represents total amount of cpu present on the node
-	// +required
-	CpuOnNodeAtBoot int64 `json:"cpuonnodeatboot"`
-	// memoryonnodeatboot represents total amount of memory present on the node
-	// +required
-	MemoryOnNodeAtBoot int64 `json:"memoryonnodeatboot"`
+	MigGPUUUID         map[string]string            `json:"MigGPUUUID,omitempty"`
+	Allocations        map[string]AllocationDetails `json:"allocations,omitempty"`
+	Migplacement       []Mig                        `json:"migplacement,omitempty"`
+	CpuOnNodeAtBoot    int64                        `json:"cpuonnodeatboot,omitempty"`
+	MemoryOnNodeAtBoot int64                        `json:"memoryonnodeatboot,omitempty"`
 }
 
 // InstasliceStatus defines the observed state of Instaslice
 type InstasliceStatus struct {
-	// processed represents state of the instaslice object after daemonset creation
-	// +required
-	Processed bool `json:"processed"`
+	Processed bool `json:"processed,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -128,21 +78,11 @@ type InstasliceStatus struct {
 
 // Instaslice is the Schema for the instaslices API
 type Instaslice struct {
-	// TypeMeta contains metadata about the API resource type.
-	// It includes information such as API version and kind.
-	metav1.TypeMeta `json:",inline"`
-	// +optional
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// spec defines the current state of different allocations in the Instaslice resource.
-	// It contains configuration details, such as GPU allocation settings,
-	// node-specific parameters, and placement preferences.
-	// +required
-	Spec InstasliceSpec `json:"spec"`
-	// status represents the observed state of the Instaslice resource.
-	// It provides runtime information about the resource, such as whether
-	// allocations have been processed.
-	// +optional
-	Status InstasliceStatus `json:"status"`
+
+	Spec   InstasliceSpec   `json:"spec,omitempty"`
+	Status InstasliceStatus `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -150,11 +90,8 @@ type Instaslice struct {
 // InstasliceList contains a list of Instaslice
 type InstasliceList struct {
 	metav1.TypeMeta `json:",inline"`
-	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
-	// items represents an entry of instaslice resource per node
-	// +required
-	Items []Instaslice `json:"items"`
+	Items           []Instaslice `json:"items"`
 }
 
 func init() {

--- a/config/crd/bases/inference.redhat.com_instaslices.yaml
+++ b/config/crd/bases/inference.redhat.com_instaslices.yaml
@@ -37,17 +37,17 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              spec defines the current state of different allocations in the Instaslice resource.
-              It contains configuration details, such as GPU allocation settings,
-              node-specific parameters, and placement preferences.
+            description: InstasliceSpec defines the desired state of Instaslice
             properties:
+              MigGPUUUID:
+                additionalProperties:
+                  type: string
+                type: object
               allocations:
                 additionalProperties:
                   description: Define the struct for allocation details
                   properties:
                     allocationStatus:
-                      description: allocationStatus represents status of allocation
                       enum:
                       - deleted
                       - deleting
@@ -56,43 +56,29 @@ spec:
                       - created
                       type: string
                     cpu:
-                      description: cpu represents amount of cpu requested by user
-                        workload
                       format: int64
                       type: integer
                     gpuUUID:
-                      description: gpuUUID represents gpu uuid of selected gpu
                       type: string
                     memory:
-                      description: memory represents amount of memory requested by
-                        user workload
                       format: int64
                       type: integer
                     namespace:
-                      description: namespace represents namespace of user workload
                       type: string
                     nodename:
-                      description: nodename represents name of the selected node
                       type: string
                     podName:
-                      description: podName represents name of the user workload pod
                       type: string
                     podUUID:
-                      description: podUUID represents uuid of user workload
                       type: string
                     profile:
-                      description: profile requested by user workload
                       type: string
                     resourceIdentifier:
-                      description: resourceIdentifier represents uuid used for creating
-                        configmap resource
                       type: string
                     size:
-                      description: size of profile that begins from start position
                       format: int32
                       type: integer
                     start:
-                      description: start position of a profile on a gpu
                       format: int32
                       type: integer
                   required:
@@ -109,55 +95,28 @@ spec:
                   - size
                   - start
                   type: object
-                description: allocations represents allocation details of user workloads
                 type: object
               cpuonnodeatboot:
-                description: cpuonnodeatboot represents total amount of cpu present
-                  on the node
                 format: int64
                 type: integer
               memoryonnodeatboot:
-                description: memoryonnodeatboot represents total amount of memory
-                  present on the node
                 format: int64
                 type: integer
-              migGpuUuid:
-                additionalProperties:
-                  type: string
-                description: migGpuUuid represents uuid of the mig device created
-                  on the gpu
-                type: object
               migplacement:
-                description: migplacement represents gpu instance, compute instance
-                  with placement for a profile
                 items:
                   properties:
-                    ciengprofileid:
-                      description: ciengprofileid provides compute instance engineering
-                        id of a profile
-                      format: int32
+                    ciProfileid:
                       type: integer
-                    ciprofileid:
-                      description: ciprofileid provides compute instance id of a profile
-                      format: int32
+                    ciengprofileid:
                       type: integer
                     giprofileid:
-                      description: giprofileid provides gpu instance id of a profile
-                      format: int32
                       type: integer
                     placements:
-                      description: placements provide vendor profile indexes and sizes
                       items:
                         properties:
                           size:
-                            description: size represents solts consumed by a profile
-                              on gpu
-                            format: int32
                             type: integer
                           start:
-                            description: start represents the begin index driven by
-                              size for a profile
-                            format: int32
                             type: integer
                         required:
                         - size
@@ -165,36 +124,20 @@ spec:
                         type: object
                       type: array
                     profile:
-                      description: profile provides name of the vendor profile
                       type: string
                   required:
-                  - ciprofileid
+                  - ciProfileid
+                  - ciengprofileid
                   - giprofileid
-                  - placements
-                  - profile
                   type: object
                 type: array
-            required:
-            - cpuonnodeatboot
-            - memoryonnodeatboot
-            - migGpuUuid
-            - migplacement
             type: object
           status:
-            description: |-
-              status represents the observed state of the Instaslice resource.
-              It provides runtime information about the resource, such as whether
-              allocations have been processed.
+            description: InstasliceStatus defines the observed state of Instaslice
             properties:
               processed:
-                description: processed represents state of the instaslice object after
-                  daemonset creation
                 type: boolean
-            required:
-            - processed
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -60,8 +60,8 @@ type InstasliceReconciler struct {
 
 // AllocationPolicy interface with a single method
 type AllocationPolicy interface {
-	SetAllocationDetails(profileName string, newStart, size int32, podUUID string, nodename string, processed string,
-		discoveredGiprofile int32, Ciprofileid int32, Ciengprofileid int32, namespace string, podName string, gpuUuid string, resourceIndetifier string,
+	SetAllocationDetails(profileName string, newStart, size uint32, podUUID string, nodename string, processed string,
+		discoveredGiprofile int, Ciprofileid int, Ciengprofileid int, namespace string, podName string, gpuUuid string, resourceIndetifier string,
 		cpumilli int64, memory int64) *inferencev1alpha1.AllocationDetails
 }
 
@@ -513,16 +513,16 @@ func (*InstasliceReconciler) extractProfileName(limits v1.ResourceList) string {
 }
 
 // Extract NVML specific attributes for GPUs, this will change for different generations of the GPU.
-func (*InstasliceReconciler) extractGpuProfile(instaslice *inferencev1alpha1.Instaslice, profileName string) (int32, int32, int32, int32) {
-	var size int32
-	var discoveredGiprofile int32
-	var Ciprofileid int32
-	var Ciengprofileid int32
+func (*InstasliceReconciler) extractGpuProfile(instaslice *inferencev1alpha1.Instaslice, profileName string) (int, int, int, int) {
+	var size int
+	var discoveredGiprofile int
+	var Ciprofileid int
+	var Ciengprofileid int
 	for _, item := range instaslice.Spec.Migplacement {
 		if item.Profile == profileName {
 			for _, aPlacement := range item.Placements {
 				size = aPlacement.Size
-				discoveredGiprofile = item.GIprofileid
+				discoveredGiprofile = item.Giprofileid
 				Ciprofileid = item.CIProfileID
 				Ciengprofileid = item.CIEngProfileID
 				break
@@ -646,8 +646,8 @@ func (r *InstasliceReconciler) removeInstaSliceFinalizer(ctx context.Context, re
 }
 
 // Policy based allocation - FirstFit
-func (r *FirstFitPolicy) SetAllocationDetails(profileName string, newStart, size int32, podUUID, nodename string,
-	processed string, discoveredGiprofile int32, Ciprofileid int32, Ciengprofileid int32,
+func (r *FirstFitPolicy) SetAllocationDetails(profileName string, newStart, size uint32, podUUID, nodename string,
+	processed string, discoveredGiprofile int, Ciprofileid int, Ciengprofileid int,
 	namespace string, podName string, gpuUuid string, resourceIdentifier string, cpuMilli int64, memory int64,
 ) *inferencev1alpha1.AllocationDetails {
 	return &inferencev1alpha1.AllocationDetails{

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -757,7 +757,7 @@ func TestInstasliceReconciler_extractGpuProfile(t *testing.T) {
 	instaslice := new(inferencev1alpha1.Instaslice)
 	instaslice.Spec = inferencev1alpha1.InstasliceSpec{
 		Migplacement: []inferencev1alpha1.Mig{
-			{Profile: "1g.5gb", Placements: []inferencev1alpha1.Placement{{Size: 1, Start: 0}}, GIprofileid: 0, CIProfileID: 1, CIEngProfileID: 2},
+			{Profile: "1g.5gb", Placements: []inferencev1alpha1.Placement{{Size: 1, Start: 0}}, Giprofileid: 0, CIProfileID: 1, CIEngProfileID: 2},
 		},
 	}
 	newArgs := args{
@@ -768,10 +768,10 @@ func TestInstasliceReconciler_extractGpuProfile(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   int32
-		want1  int32
-		want2  int32
-		want3  int32
+		want   int
+		want1  int
+		want2  int
+		want3  int
 	}{
 		{"Test-case", newFields, newArgs, 1, 0, 1, 2},
 	}
@@ -842,14 +842,14 @@ func TestInstasliceReconciler_podMapFunc(t *testing.T) {
 func TestFirstFitPolicy_SetAllocationDetails(t *testing.T) {
 	type args struct {
 		profileName         string
-		newStart            int32
-		size                int32
+		newStart            uint32
+		size                uint32
 		podUUID             string
 		nodename            string
 		processed           string
-		discoveredGiprofile int32
-		Ciprofileid         int32
-		Ciengprofileid      int32
+		discoveredGiprofile int
+		Ciprofileid         int
+		Ciengprofileid      int
 		namespace           string
 		podName             string
 		gpuUuid             string

--- a/internal/controller/utils/emulated.go
+++ b/internal/controller/utils/emulated.go
@@ -22,7 +22,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    0,
 					CIEngProfileID: 0,
-					GIprofileid:    0,
+					Giprofileid:    0,
 					Placements: []v1alpha1.Placement{
 						{Size: 1, Start: 0},
 						{Size: 1, Start: 1},
@@ -37,7 +37,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    1,
 					CIEngProfileID: 0,
-					GIprofileid:    1,
+					Giprofileid:    1,
 					Placements: []v1alpha1.Placement{
 						{Size: 2, Start: 0},
 						{Size: 2, Start: 2},
@@ -48,7 +48,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    2,
 					CIEngProfileID: 0,
-					GIprofileid:    2,
+					Giprofileid:    2,
 					Placements: []v1alpha1.Placement{
 						{Size: 4, Start: 0},
 						{Size: 4, Start: 4},
@@ -58,7 +58,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    3,
 					CIEngProfileID: 0,
-					GIprofileid:    3,
+					Giprofileid:    3,
 					Placements: []v1alpha1.Placement{
 						{Size: 4, Start: 0},
 					},
@@ -67,7 +67,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    4,
 					CIEngProfileID: 0,
-					GIprofileid:    4,
+					Giprofileid:    4,
 					Placements: []v1alpha1.Placement{
 						{Size: 8, Start: 0},
 					},
@@ -76,7 +76,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    7,
 					CIEngProfileID: 0,
-					GIprofileid:    7,
+					Giprofileid:    7,
 					Placements: []v1alpha1.Placement{
 						{Size: 1, Start: 0},
 						{Size: 1, Start: 1},
@@ -91,7 +91,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 				{
 					CIProfileID:    9,
 					CIEngProfileID: 0,
-					GIprofileid:    9,
+					Giprofileid:    9,
 					Placements: []v1alpha1.Placement{
 						{Size: 2, Start: 0},
 						{Size: 2, Start: 2},


### PR DESCRIPTION
This reverts commit d9ad4fb472e1bd086d35ecff9dc88340c2d604fb.


`d9ad4fb472e1bd086d35ecff9dc88340c2d604fb` fails to schedule a pod with following errors from the controller pod in non-emulated mode in OCP (not sure if this happens on kind as well) 

```
{"level":"info","ts":"2025-01-23T19:13:32.509870409Z","caller":"controller/capacity.go:59","msg":" memory requests not set for ","controller":"InstaSlice-controller","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"cuda-vectoradd-1","namespace":"instaslice-system"},"namespace":"instaslice-system","name":"cuda-vectoradd-1","reconcileID":"731356a2-ea02-4ab9-8383-8f637a1d928d","pod":"cuda-vectoradd-1"}
{"level":"info","ts":"2025-01-23T19:13:32.509891295Z","caller":"controller/instaslice_controller.go:410","msg":"no suitable node found in cluster for ","controller":"InstaSlice-controller","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"cuda-vectoradd-1","namespace":"instaslice-system"},"namespace":"instaslice-system","name":"cuda-vectoradd-1","reconcileID":"731356a2-ea02-4ab9-8383-8f637a1d928d","pod":"cuda-vectoradd-1"}
```
Notice the missing pod name at the end of `msg` string. Reverting this change makes the tests pass in non-emulator mode. 

But it seems like there is more to the emulator mode, looking into it. 