### PR TITLE
Revert "operator: imagePullPolicy to always"

### DIFF
--- a/config/manager-ocp/manager.yaml
+++ b/config/manager-ocp/manager.yaml
@@ -71,7 +71,7 @@ spec:
         args:
         - --leader-elect
         image: controller:latest
-        imagePullPolicy: Always
+        #imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Reverts openshift/instaslice-operator#412 as it fails the `make test-e2e-kind-emulated`

/cc @harche @asm582 @rphillips 