### PR TITLE
OCPNODE-2882: Handle unexpected node reboots

### DIFF
--- a/internal/controller/daemonset/instaslice_daemonset_test.go
+++ b/internal/controller/daemonset/instaslice_daemonset_test.go
@@ -156,6 +156,10 @@ func TestInstaSliceDaemonsetReconciler_Reconcile_Creating_Alloc_Status(t *testin
 
 	// Create a background context
 	ctx := context.Background()
+	// Create a node object so that the daemonset would not return a requeued reconcile request
+	node := v1.Node{}
+	node.Name = nodeName
+	assert.NoError(t, client.Create(ctx, &node))
 
 	// Create an instaslice object
 	instaslice := newInstaslice(nodeName, podUUID, inferencev1alpha1.AllocationStatusCreating)

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -61,6 +61,9 @@ func UpdateOrDeleteInstasliceAllocations(ctx context.Context, kubeClient client.
 	}
 	if allocation != nil {
 		newInstaslice.Spec.Allocations[allocation.PodUUID] = *allocation
+		if !newInstaslice.Status.Processed {
+			newInstaslice.Status.Processed = true
+		}
 	}
 	err = kubeClient.Patch(ctx, &newInstaslice, client.MergeFrom(original))
 	if err != nil {


### PR DESCRIPTION
Potentially
Fixes https://github.com/openshift/instaslice-operator/issues/336

`make test`, `make lint`, pass locally
`make test-e2e-kind-emulated` passes with some tweaks to the config files.

/hold
- until a few more e2e test scenarios are added
- thoroughly tested on the real GPU covering all the scenarios