### PR TITLE
OCPNODE-3015: Support node reboots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-e2e-kind-emulated: export KIND_NAME=kind-e2e
 test-e2e-kind-emulated: export KIND_CONTEXT=kind-kind-e2e
 test-e2e-kind-emulated: export KIND_NODE_NAME=${KIND_NAME}-control-plane
 test-e2e-kind-emulated: export EMULATOR_MODE=true
-test-e2e-kind-emulated: docker-build create-kind-cluster deploy-cert-manager deploy-instaslice-emulated-on-kind
+test-e2e-kind-emulated: docker-build docker-push create-kind-cluster deploy-cert-manager deploy-instaslice-emulated-on-kind
 	export KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
 		ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m ./test/e2e
 

--- a/api/v1alpha1/instaslice_types.go
+++ b/api/v1alpha1/instaslice_types.go
@@ -115,6 +115,10 @@ type DiscoveredNodeResources struct {
 	// nodeResources represents the resource list of the node at boot time
 	// +required
 	NodeResources corev1.ResourceList `json:"nodeResources"`
+
+	// bootId represents the current boot id of the node
+	// +kubebuilder:validation:Required
+	BootID string `json:"bootId"`
 }
 
 type Mig struct {

--- a/bundle-ocp/manifests/inference.redhat.com_instaslices.yaml
+++ b/bundle-ocp/manifests/inference.redhat.com_instaslices.yaml
@@ -239,6 +239,9 @@ spec:
                 description: nodeResources specifies the discovered resources of the
                   node
                 properties:
+                  bootId:
+                    description: bootId represents the current boot id of the node
+                    type: string
                   migPlacement:
                     additionalProperties:
                       properties:
@@ -321,6 +324,7 @@ spec:
                       node at boot time
                     type: object
                 required:
+                - bootId
                 - migPlacement
                 - nodeGpus
                 - nodeResources

--- a/config/crd/bases/inference.redhat.com_instaslices.yaml
+++ b/config/crd/bases/inference.redhat.com_instaslices.yaml
@@ -238,6 +238,9 @@ spec:
                 description: nodeResources specifies the discovered resources of the
                   node
                 properties:
+                  bootId:
+                    description: bootId represents the current boot id of the node
+                    type: string
                   migPlacement:
                     additionalProperties:
                       properties:
@@ -320,6 +323,7 @@ spec:
                       node at boot time
                     type: object
                 required:
+                - bootId
                 - migPlacement
                 - nodeGpus
                 - nodeResources

--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
 	"github.com/openshift/instaslice-operator/internal/controller"
@@ -30,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -337,7 +336,7 @@ func (r *InstaSliceDaemonsetReconciler) createCiAndGiProfiles(ctx context.Contex
 	ciProfileID := selectedMig.CIProfileID
 
 	createdMigInfos, err := r.createSliceAndPopulateMigInfos(
-		ctx, device, &allocResult, giProfileInfo, placement, ciProfileID, podRef.Name)
+		ctx, device, giProfileInfo, placement, ciProfileID, podRef.Name)
 	if err != nil {
 		log.Error(err, "MIG creation not successful")
 		return err

--- a/internal/controller/daemonset/instaslice_daemonset_test.go
+++ b/internal/controller/daemonset/instaslice_daemonset_test.go
@@ -110,6 +110,14 @@ func TestInstaSliceDaemonsetReconciler_Reconcile_Deleting_Alloc_Status(t *testin
 		Name:      nodeName,
 		Namespace: controller.InstaSliceOperatorNamespace,
 	}
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instaslice.Name,
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{BootID: instaslice.Status.NodeResources.BootID},
+		},
+	}
 	req := ctrl.Request{
 		NamespacedName: typeNamespacedName,
 	}
@@ -121,6 +129,7 @@ func TestInstaSliceDaemonsetReconciler_Reconcile_Deleting_Alloc_Status(t *testin
 	assert.Equal(t, result, ctrl.Result{})
 
 	// Testcase 2: reconcile for an AllocationStatusDeleting
+	assert.NoError(t, reconciler.Client.Create(ctx, node))
 	assert.NoError(t, reconciler.Client.Create(ctx, instaslice))
 	result, err = reconciler.Reconcile(ctx, req)
 	assert.NoError(t, err)
@@ -165,8 +174,17 @@ func TestInstaSliceDaemonsetReconciler_Reconcile_Creating_Alloc_Status(t *testin
 	req := ctrl.Request{
 		NamespacedName: typeNamespacedName,
 	}
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instaslice.Name,
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{BootID: instaslice.Status.NodeResources.BootID},
+		},
+	}
 
 	// Testcase 4: reconcile for an AllocationStatusDeleting
+	assert.NoError(t, reconciler.Client.Create(ctx, node))
 	assert.NoError(t, reconciler.Client.Create(ctx, instaslice))
 	result, err := reconciler.Reconcile(ctx, req)
 	assert.NoError(t, err)
@@ -187,6 +205,7 @@ func newInstaslice(name, podUUID string, status inferencev1alpha1.AllocationStat
 					AllocationStatus: status,
 				},
 			},
+			NodeResources: inferencev1alpha1.DiscoveredNodeResources{BootID: "random-boot-id"},
 		},
 	}
 }
@@ -222,6 +241,7 @@ func TestInstaSliceDaemonsetReconciler_addMigCapacityToNode(t *testing.T) {
 	// create a fake node object
 	node := &v1.Node{}
 	node.Name = nodeName
+	node.Status.NodeInfo.BootID = "random-boot-id"
 	assert.NoError(t, client.Create(ctx, node))
 	// Create an instaslice object
 	instaslice := newInstaslice(nodeName, podUUID, inferencev1alpha1.AllocationStatus{AllocationStatusController: inferencev1alpha1.AllocationStatusCreating})

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -414,6 +414,15 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 							ConfigMapResourceIdentifier: "fake-configmap-uid",
 						},
 					},
+					NodeResources: inferencev1alpha1.DiscoveredNodeResources{BootID: "fake-boot-id"},
+				},
+			}
+			node := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: instaslice.Name,
+				},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{BootID: instaslice.Status.NodeResources.BootID},
 				},
 			}
 
@@ -442,6 +451,7 @@ func TestInstasliceReconciler_Reconcile(t *testing.T) {
 				},
 			}
 
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
 			Expect(fakeClient.Create(ctx, daemonSet)).To(Succeed())
 			Expect(fakeClient.Create(ctx, instaslice)).To(Succeed())
 			Expect(fakeClient.Create(ctx, pod)).To(Succeed())

--- a/internal/controller/utils/emulated.go
+++ b/internal/controller/utils/emulated.go
@@ -112,6 +112,7 @@ func GenerateFakeCapacity(nodeName string) *v1alpha1.Instaslice {
 					v1.ResourceCPU:    resource.MustParse("72"),
 					v1.ResourceMemory: resource.MustParse("1000000000"),
 				},
+				BootID: "fake-boot-id",
 			},
 		},
 	}


### PR DESCRIPTION
Add `BootID` to the InstasliceSpec object to support the node reboots

- BootID is required to store the current bootId present on the node obtained from the `Node` object
- It is required to determine if a node underwent a reboot

Fixes https://github.com/openshift/instaslice-operator/issues/336