### PR TITLE
remove ecosystem-cert-preflight-check from bundle pipelines

### DIFF
--- a/.tekton/instaslice-operator-bundle-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-pull-request.yaml
@@ -333,26 +333,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/instaslice-operator-bundle-push.yaml
+++ b/.tekton/instaslice-operator-bundle-push.yaml
@@ -330,26 +330,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -339,7 +339,7 @@ spec:
                 - name: RELATED_IMAGE_INSTASLICE_DAEMONSET
                   value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset@sha256:dc6286cbeaa2ada8cbb45299823c8ab582fcb43f10b1f19cfb2fd1f83dac9479
                 - name: EMULATOR_MODE
-                  value: "false"
+                  value: "true"
                 image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:7eae1f3f74a2f0a012d13772360d5638542827e6a20526b8b9da7116d0f8745e
                 imagePullPolicy: Always
                 livenessProbe:


### PR DESCRIPTION
fix issue where ecosystem-cert-preflight-check is skipped for bundles but EC fails because it is skipped.  Also changed "EMULATOR_MODE: true" in CSV as the e2e test require that and I missed that in the other PR.