### PR TITLE
Handle incorrect allocations in the system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,11 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | sed -e "s|<IMG_DMST>|$(IMG_DMST)|g" | $(KUBECTL) apply -f -
 
+.PHONY: deploy-dry-run
+deploy-dry-run: manifests kustomize ## Perform a dry-run deployment and save output to deploy-dry-run.yaml.
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/$(KUSTOMIZATION) | sed -e "s|<IMG_DMST>|$(IMG_DMST)|g" | $(KUBECTL) apply --dry-run=client -f - > deploy-dry-run.yaml
+
 .PHONY: ocp-deploy
 ocp-deploy: container-build-ocp docker-push bundle-ocp bundle-build-ocp bundle-push deploy-instaslice-on-ocp
 

--- a/internal/controller/cache.go
+++ b/internal/controller/cache.go
@@ -20,12 +20,13 @@ import (
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Cache avoids non determinism in the system which occurs when we play
 // catch game by being upto date with .status.podallocationresults. status
-// takes time to propogate and often causes controller to assign same slice
+// takes time to propagate and often causes controller to assign same slice
 // to multiple pods.
 
 func (r *InstasliceReconciler) rebuildAllocationCache(ctx context.Context) error {
@@ -38,15 +39,17 @@ func (r *InstasliceReconciler) rebuildAllocationCache(ctx context.Context) error
 	// TODO: cache is rebuilt on node failure we should
 	// avoid instaslice objects that are related to failed
 	// nodes in the cluster.
-	var instasliceList inferencev1alpha1.InstasliceList
-	if err := r.List(ctx, &instasliceList); err != nil {
-		logr.FromContext(ctx).Error(err, "Error listing Instaslice objects")
+	// Fetch all Instaslice objects using the lister
+	instaslices := &inferencev1alpha1.InstasliceList{}
+	// Use cached informer to list Instaslice objects
+	if err := r.Client.List(ctx, instaslices, client.InNamespace(InstaSliceOperatorNamespace)); err != nil {
+		log.FromContext(ctx).Error(err, "Error listing Instaslice objects from cache")
 		return err
 	}
 
 	r.allocationCache = make(map[types.UID]inferencev1alpha1.AllocationResult)
 
-	for _, instaslice := range instasliceList.Items {
+	for _, instaslice := range instaslices.Items {
 		for podUid, allocResult := range instaslice.Status.PodAllocationResults {
 			if allocResult.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
 				continue
@@ -59,7 +62,30 @@ func (r *InstasliceReconciler) rebuildAllocationCache(ctx context.Context) error
 	return nil
 }
 
-func (r *InstasliceReconciler) updateCacheWithNewAllocation(ctx context.Context, podUid types.UID, allocResult inferencev1alpha1.AllocationResult) {
+func (r *InstasliceReconciler) updateCacheWithNewAllocation(podUid types.UID, allocResult inferencev1alpha1.AllocationResult) {
 
 	r.allocationCache[podUid] = allocResult
+}
+
+// clean allocations that do not exists in spec
+// TODO fix scalability issue, loops over all instaslice objects in the cluster
+func (r *InstasliceReconciler) CleanupOrphanedAllocations(instasliceList *inferencev1alpha1.InstasliceList) {
+	var keysToDelete []types.UID
+
+	for uuid := range r.allocationCache {
+		found := false
+		for _, instaslice := range instasliceList.Items {
+			if _, exists := instaslice.Spec.PodAllocationRequests[uuid]; exists {
+				found = true
+				break
+			}
+		}
+		if !found {
+			keysToDelete = append(keysToDelete, uuid)
+		}
+	}
+
+	for _, uuid := range keysToDelete {
+		delete(r.allocationCache, uuid)
+	}
 }

--- a/internal/controller/cache.go
+++ b/internal/controller/cache.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"context"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	logr "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Cache avoids non determinism in the system which occurs when we play
+// catch game by being upto date with .status.podallocationresults. status
+// takes time to propogate and often causes controller to assign same slice
+// to multiple pods.
+
+func (r *InstasliceReconciler) rebuildAllocationCache(ctx context.Context) error {
+	// Only rebuild if the cache is empty (indicating a controller restart)
+	if r.isCacheInitialized {
+		return nil
+	}
+
+	// Fetch all Instaslice objects in the cluster
+	// TODO: cache is rebuilt on node failure we should
+	// avoid instaslice objects that are related to failed
+	// nodes in the cluster.
+	var instasliceList inferencev1alpha1.InstasliceList
+	if err := r.List(ctx, &instasliceList); err != nil {
+		logr.FromContext(ctx).Error(err, "Error listing Instaslice objects")
+		return err
+	}
+
+	r.allocationCache = make(map[types.UID]inferencev1alpha1.AllocationResult)
+
+	for _, instaslice := range instasliceList.Items {
+		for podUid, allocResult := range instaslice.Status.PodAllocationResults {
+			if allocResult.AllocationStatus.AllocationStatusDaemonset == inferencev1alpha1.AllocationStatusDeleted {
+				continue
+			}
+			r.allocationCache[podUid] = allocResult
+		}
+	}
+
+	r.isCacheInitialized = true
+	return nil
+}
+
+func (r *InstasliceReconciler) updateCacheWithNewAllocation(ctx context.Context, podUid types.UID, allocResult inferencev1alpha1.AllocationResult) {
+
+	r.allocationCache[podUid] = allocResult
+}

--- a/internal/controller/capacity.go
+++ b/internal/controller/capacity.go
@@ -63,7 +63,7 @@ func (r *InstasliceReconciler) findNodeAndDeviceForASlice(ctx context.Context, i
 				updatedInstaSliceObject.Spec.PodAllocationRequests = make(map[types.UID]inferencev1alpha1.AllocationRequest)
 			}
 
-			newStart := r.getStartIndexFromAllocationResults(ctx, updatedInstaSliceObject, gpuuuid, profileName, pod.UID)
+			newStart := r.getStartIndexFromAllocationResults(updatedInstaSliceObject, gpuuuid, profileName, pod.UID)
 			// For example, a newStart of 9 is considered invalid.
 			notValidIndex := int32(9)
 			if newStart == notValidIndex {
@@ -110,19 +110,8 @@ func sortGPUs(updatedInstaSliceObject *inferencev1alpha1.Instaslice) []string {
 }
 
 // accounting logic that finds the correct GPU and index where a slice could be placed.
-func (r *InstasliceReconciler) getStartIndexFromAllocationResults(ctx context.Context, instaslice *inferencev1alpha1.Instaslice, gpuUUID string, profileName string, podUid types.UID) int32 {
+func (r *InstasliceReconciler) getStartIndexFromAllocationResults(instaslice *inferencev1alpha1.Instaslice, gpuUUID string, profileName string, podUid types.UID) int32 {
 	//TODO: generalize, A100 and H100 have 8 indexes for 3g and 7g and 7 for rest, so go with 8 and we are bounded by
-	//only valid placement indexes for a profile.
-	// clean allocations that do not exists in spec
-	var keysToDelete []types.UID
-	for uuid := range r.allocationCache {
-		if _, exists := instaslice.Spec.PodAllocationRequests[uuid]; !exists {
-			keysToDelete = append(keysToDelete, uuid)
-		}
-	}
-	for _, uuid := range keysToDelete {
-		delete(r.allocationCache, uuid)
-	}
 	allocResult, exists := r.allocationCache[podUid]
 	// allocation already exists in cache
 	if exists {

--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -140,12 +140,18 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 
 			log.Info("Performing cleanup for pod", "podRef", podRef)
 			if !r.Config.EmulatorModeEnable {
-
-				err := r.cleanUpCiAndGi(ctx, &allocResult, podRef)
+				exists, err := r.checkConfigMapExists(ctx, string(allocResult.ConfigMapResourceIdentifier), podRef.Namespace)
 				if err != nil {
-					// NVML shutdowm took time or NVML init may have failed.
-					log.Error(err, "error cleaning up ci and gi retrying", podRef)
+					log.Error(err, "error checking configmap existence", "podRef", podRef)
 					return ctrl.Result{RequeueAfter: controller.Requeue2sDelay}, err
+				}
+				if exists {
+					err := r.cleanUpCiAndGi(ctx, &allocResult, podRef)
+					if err != nil {
+						// NVML shutdowm took time or NVML init may have failed.
+						log.Error(err, "error cleaning up ci and gi retrying", podRef)
+						return ctrl.Result{RequeueAfter: controller.Requeue2sDelay}, err
+					}
 				}
 			}
 			err := r.deleteConfigMap(ctx,
@@ -175,10 +181,6 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 				log.Error(err, "error obtianing configmap", string(allocResult.ConfigMapResourceIdentifier))
 				return ctrl.Result{RequeueAfter: controller.Requeue2sDelay}, err
 			}
-			if exists {
-				log.Info("Skipping updating pod", "podRef", podRef)
-				continue
-			}
 			log.Info("creating allocation for pod", "podRef", podRef)
 			// We can look up the *request* in spec to see the profile or resource demands
 			allocationRequest, haveReq := instaslice.Spec.PodAllocationRequests[podUID]
@@ -187,59 +189,60 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 				log.Info("No matching PodAllocationRequest for this result; skipping", podRef)
 				continue
 			}
+			if !exists {
+				if r.Config.EmulatorModeEnable {
+					// configmap with fake MIG uuid
+					err := r.createConfigMap(ctx,
+						string(allocResult.ConfigMapResourceIdentifier),
+						podRef.Namespace,
+						string(allocResult.ConfigMapResourceIdentifier))
+					if err != nil {
+						log.Error(err, "failed to create config map (emulator mode)")
+						return ctrl.Result{RequeueAfter: controller.Requeue1sDelay}, err
+					}
+					// Emulating cost to create CI and GI on a GPU
+					time.Sleep(controller.Requeue1sDelay)
+				} else {
+					device, retCode := nvml.DeviceGetHandleByUUID(allocResult.GPUUUID)
+					if retCode != nvml.SUCCESS {
+						log.Error(retCode, "error getting GPU device handle", "gpuUUID", allocResult.GPUUUID)
+						return ctrl.Result{}, goerror.New("error fetching GPU device handle")
+					}
 
-			if r.Config.EmulatorModeEnable {
-				// configmap with fake MIG uuid
-				err := r.createConfigMap(ctx,
-					string(allocResult.ConfigMapResourceIdentifier),
-					podRef.Namespace,
-					string(allocResult.ConfigMapResourceIdentifier))
-				if err != nil {
-					log.Error(err, "failed to create config map (emulator mode)")
-					return ctrl.Result{RequeueAfter: controller.Requeue1sDelay}, err
-				}
-				// Emulating cost to create CI and GI on a GPU
-				time.Sleep(controller.Requeue1sDelay)
-			} else {
-				device, retCode := nvml.DeviceGetHandleByUUID(allocResult.GPUUUID)
-				if retCode != nvml.SUCCESS {
-					log.Error(retCode, "error getting GPU device handle", "gpuUUID", allocResult.GPUUUID)
-					return ctrl.Result{}, goerror.New("error fetching GPU device handle")
-				}
+					selectedMig, ok := instaslice.Status.NodeResources.MigPlacement[allocationRequest.Profile]
+					if !ok {
+						log.Info("No suitable MIG profile in NodeResources; skipping creation", podRef, allocResult)
+						continue
+					}
 
-				selectedMig, ok := instaslice.Status.NodeResources.MigPlacement[allocationRequest.Profile]
-				if !ok {
-					log.Info("No suitable MIG profile in NodeResources; skipping creation", podRef, allocResult)
-					continue
-				}
+					placement := nvml.GpuInstancePlacement{
+						Start: uint32(allocResult.MigPlacement.Start),
+						Size:  uint32(allocResult.MigPlacement.Size),
+					}
 
-				placement := nvml.GpuInstancePlacement{
-					Start: uint32(allocResult.MigPlacement.Start),
-					Size:  uint32(allocResult.MigPlacement.Size),
-				}
+					giProfileInfo, retGI := device.GetGpuInstanceProfileInfo(int(selectedMig.GIProfileID))
+					if retGI != nvml.SUCCESS {
+						log.Error(retGI, "error getting GPU instance profile info", "GIProfileID", selectedMig.GIProfileID)
+						return ctrl.Result{}, goerror.New("cannot get GI profile info")
+					}
 
-				giProfileInfo, retGI := device.GetGpuInstanceProfileInfo(int(selectedMig.GIProfileID))
-				if retGI != nvml.SUCCESS {
-					log.Error(retGI, "error getting GPU instance profile info", "GIProfileID", selectedMig.GIProfileID)
-					return ctrl.Result{}, goerror.New("cannot get GI profile info")
-				}
+					ciProfileID := selectedMig.CIProfileID
 
-				ciProfileID := selectedMig.CIProfileID
+					createdMigInfos, err := r.createSliceAndPopulateMigInfos(
+						ctx, device, &allocResult, giProfileInfo, placement, ciProfileID, podRef.Name)
+					if err != nil {
+						log.Error(err, "MIG creation not successful", "podRef", podRef)
+						return ctrl.Result{RequeueAfter: controller.Requeue2sDelay}, err
+					}
 
-				createdMigInfos, err := r.createSliceAndPopulateMigInfos(
-					ctx, device, &allocResult, giProfileInfo, placement, ciProfileID, podRef.Name)
-				if err != nil {
-					log.Error(err, "MIG creation not successful", podRef)
-					return ctrl.Result{RequeueAfter: controller.Requeue2sDelay}, err
-				}
-
-				for migUuid, migDevice := range createdMigInfos {
-					if migDevice.start == allocResult.MigPlacement.Start && migDevice.uuid == allocResult.GPUUUID && giProfileInfo.Id == migDevice.giInfo.ProfileId {
-						if err := r.createConfigMap(ctx, migUuid, podRef.Namespace, string(allocResult.ConfigMapResourceIdentifier)); err != nil {
-							return ctrl.Result{RequeueAfter: controller.Requeue1sDelay}, err
+					for migUuid, migDevice := range createdMigInfos {
+						if migDevice.start == allocResult.MigPlacement.Start && migDevice.uuid == allocResult.GPUUUID && giProfileInfo.Id == migDevice.giInfo.ProfileId {
+							if err := r.createConfigMap(ctx, migUuid, podRef.Namespace, string(allocResult.ConfigMapResourceIdentifier)); err != nil {
+								return ctrl.Result{RequeueAfter: controller.Requeue1sDelay}, err
+							}
+							log.Info("done creating mig slice for ", "pod", podRef.Name, "parentgpu", allocResult.GPUUUID, "miguuid", migUuid)
+							break
 						}
-						log.Info("done creating mig slice for ", "pod", podRef.Name, "parentgpu", allocResult.GPUUUID, "miguuid", migUuid)
-						break
 					}
 				}
 			}
@@ -273,8 +276,9 @@ func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allo
 		return fmt.Errorf("unable to walk MIGs: %v", err)
 	}
 
-	for _, migdevice := range migInfos {
-		if migdevice.uuid == allocationResult.GPUUUID && migdevice.start == allocationResult.MigPlacement.Start {
+	for miguuid, migdevice := range migInfos {
+		if migdevice.uuid == allocationResult.GPUUUID && migdevice.start == allocationResult.MigPlacement.Start &&
+			migdevice.size == allocationResult.MigPlacement.Size {
 			gi, ret := parent.GetGpuInstanceById(int(migdevice.giInfo.Id))
 			if ret != nvml.SUCCESS {
 				log.Error(ret, "error obtaining gpu instance")
@@ -296,7 +300,7 @@ func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allo
 				return fmt.Errorf("unable to destroy GI: %v", ret)
 			}
 
-			log.Info("Successfully destroyed MIG resources", "allocationResult", allocationResult, "podRef", podRef)
+			log.Info("Successfully destroyed MIG resources", "allocationResult", allocationResult, "podRef", podRef, "MIGuuid", miguuid)
 			return nil
 		}
 	}
@@ -885,47 +889,12 @@ func populateMigDeviceInfos(device nvml.Device) (map[string]*MigDeviceInfo, erro
 
 func (r *InstaSliceDaemonsetReconciler) createSliceAndPopulateMigInfos(ctx context.Context, device nvml.Device, allocationResult *inferencev1alpha1.AllocationResult, giProfileInfo nvml.GpuInstanceProfileInfo, placement nvml.GpuInstancePlacement, ciProfileId int32, podName string) (map[string]*MigDeviceInfo, error) {
 	log := logr.FromContext(ctx)
-
 	log.Info("creating slice for", "pod", podName)
 	var gi nvml.GpuInstance
 	var ret nvml.Return
 	gi, ret = device.CreateGpuInstanceWithPlacement(&giProfileInfo, &placement)
 	if ret != nvml.SUCCESS {
-		switch ret {
-		case nvml.ERROR_INSUFFICIENT_RESOURCES:
-			// Handle insufficient resources case
-			gpuInstances, ret := device.GetGpuInstances(&giProfileInfo)
-			if ret != nvml.SUCCESS {
-				log.Error(ret, "gpu instances cannot be listed")
-				return nil, fmt.Errorf("gpu instances cannot be listed: %v", ret)
-			}
-
-			for _, gpuInstance := range gpuInstances {
-				gpuInstanceInfo, ret := gpuInstance.GetInfo()
-				if ret != nvml.SUCCESS {
-					log.Error(ret, "unable to obtain gpu instance info")
-					return nil, fmt.Errorf("unable to obtain gpu instance info: %v", ret)
-				}
-
-				parentUuid, ret := gpuInstanceInfo.Device.GetUUID()
-				if ret != nvml.SUCCESS {
-					log.Error(ret, "unable to obtain parent gpu uuuid")
-					return nil, fmt.Errorf("unable to obtain parent gpu uuuid: %v", ret)
-				}
-
-				if gpuInstanceInfo.Placement.Start == uint32(allocationResult.MigPlacement.Start) && parentUuid == allocationResult.GPUUUID {
-					gi, ret = device.GetGpuInstanceById(int(gpuInstanceInfo.Id))
-					if ret != nvml.SUCCESS {
-						log.Error(ret, "unable to obtain gi post iteration")
-						return nil, fmt.Errorf("unable to obtain gi post iteration: %v", ret)
-					}
-				}
-			}
-		default:
-			// this case is typically for scenario where ret is not equal to nvml.ERROR_INSUFFICIENT_RESOURCES
-			log.Error(ret, "gpu instance creation errored out with unknown error")
-			return nil, fmt.Errorf("gpu instance creation failed: %v", ret)
-		}
+		return nil, fmt.Errorf("error creating gpu instance profile with: %v", ret)
 	}
 
 	ciProfileInfo, ret := gi.GetComputeInstanceProfileInfo(int(ciProfileId), 0)


### PR DESCRIPTION
- At scale, the InstaSlice controller is not able to handle allocations for short tasks as it relies on sub-resource status, which takes a while to update, causing different pods to use the same allocation in the system while servicing short tasks. This PR introduces a cache in the system that brings determinism into the system while servicing pods with 2-second tasks. E2E's pass in emulator and non-emulator mode, and existing unit tests pass. 
- PR also retries InstaSlice status updates in scenarios when configmap is not present but the CR needs an update