### PR TITLE
initial pod filter impl

### DIFF
--- a/internal/controller/pod_webhook.go
+++ b/internal/controller/pod_webhook.go
@@ -80,6 +80,11 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 		},
 	})
 
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations["instaslice.redhat.com/mutated"] = "true"
+
 	// Marshal the updated pod object back to JSON
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {


### PR DESCRIPTION
The controller will only watch pods that have annotation - `"instaslice.redhat.com/mutated" = "true"`

Have tested this PR on top of #442. This PR has a dependency on 442 getting merged. E2E passes in both modes.