### PR TITLE
update go vers to 1.23

### DIFF
--- a/Dockerfile.daemonset-ocp
+++ b/Dockerfile.daemonset-ocp
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS build
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS build
 
 WORKDIR /workspace
 

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS build
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS build
 
 #ENV GOPATH=/go
 #ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/instaslice-operator
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.0
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible


### PR DESCRIPTION
k8s bump #459  looks like it requires go 1.23.  I updated the OCP Dockerfiles and go.mod to 1.23.  Builds complete on this branch and on the #459 branch.  I have not done any functional testing, yet.