### PR TITLE
use go 1.23 image for e2e tests

### DIFF
--- a/.tekton/integration-tests/deploy-operator.yaml
+++ b/.tekton/integration-tests/deploy-operator.yaml
@@ -256,7 +256,7 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/rhel9/go-toolset:1.22.9
+            image: registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19
             script: |
               # git clone https://github.com/cpmeadors/instaslice-operator # for testing
               git clone https://github.com/openshift/instaslice-operator


### PR DESCRIPTION
forgot to update the base image for the e2e tests when I updated the go lang version.  The konflux job "test-for-pr463" is the verification for this.