### PR TITLE
[Updated] Add custom metrics

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -59,6 +59,12 @@ func init() {
 }
 
 func main() {
+	// Log info before initializing metrics exporter
+	ctrl.Log.Info("Initializing Metrics Exporter.")
+	controller.RegisterMetrics()
+	// Log info after the metrics exporter is initialized
+	ctrl.Log.Info("Metrics Exporter Initialized.")
+
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -78,6 +78,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
+          runAsUser: 1000
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/instaslice-metrics-service.yaml
+++ b/deploy/instaslice-metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: instaslice-metrics
+  namespace: instaslice-system
+  labels:
+    control-plane: controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager  # Use the correct label here

--- a/deploy/instaslice-servicemonitor.yaml
+++ b/deploy/instaslice-servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: instaslice-monitor
+  namespace: instaslice-monitoring
+  labels:
+    release: prometheus  # Label to match Prometheus serviceMonitorSelector
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager # Match labels of the Service exposing metrics
+  namespaceSelector:
+    matchNames:
+      - instaslice-system  # Namespace where the Service resides
+  endpoints:
+    - port: metrics  # Port name exposed in the Service for kube-rbac-proxy
+      interval: 15s
+      path: /metrics
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token  # Prometheus authentication
+      honorLabels: true
+      tlsConfig:
+        insecureSkipVerify: true  # Set to false if using a valid CA

--- a/deploy/prometheus-role.yaml
+++ b/deploy/prometheus-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-metrics-reader
+  namespace: instaslice-system
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+

--- a/deploy/prometheus-rolebinding.yaml
+++ b/deploy/prometheus-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-metrics-binding
+  namespace: instaslice-system
+subjects:
+- kind: ServiceAccount
+  name: prometheus-kube-prometheus-prometheus  # Change this to your Prometheus ServiceAccount
+  namespace: instaslice-monitoring  # Change to Prometheus namespace
+roleRef:
+  kind: Role
+  name: prometheus-metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/prometheus-serviceaccount.yaml
+++ b/deploy/prometheus-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: instaslice-monitoring  # namespace where Prometheus is running

--- a/deploy/prometheus.yaml
+++ b/deploy/prometheus.yaml
@@ -1,0 +1,36 @@
+alertmanager:
+    enabled: false
+kube-state-metrics:
+    enabled: false
+prometheus-node-exporter:
+    enabled: false
+prometheus-pushgateway:
+    enabled: false
+server:
+    name: instaslice
+    service:
+        enabled: true
+        type: NodePort
+        servicePort: 9090
+    persistentVolume:
+        existingClaim: prometheus-instaslice
+        enabled: false
+    securityContext:
+        runAsUser:
+        runAsNonRoot:
+        runAsGroup:
+        fsGroup:
+extraScrapeConfigs: |
+    - job_name: instaslice-metrics
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: https
+      scrape_interval: 15s
+      static_configs:
+          - targets:
+              - instaslice-metrics.instaslice-system.svc.cluster.local:8443
+      tls_config:
+        insecure_skip_verify: true
+serviceMonitorSelector:
+    matchLabels:
+        release: prometheus

--- a/docs/enable-promethues-metrics.md
+++ b/docs/enable-promethues-metrics.md
@@ -1,0 +1,63 @@
+# Enabling Prometheus for Instaslice Monitoring
+
+## Overview
+This document outlines the steps to enable Prometheus monitoring for Instaslice, including setting up Prometheus, configuring metrics collection, and verifying the setup. The following guide follows a **happy path** approach, ensuring a smooth deployment process. Controller failure fault tolerances and additional reliability mechanisms will be added in future work. **Unit tests have been added**, and **end-to-end (E2E) tests for metrics will be incorporated in future work.**
+
+## Available Custom Instaslice Metrics
+Instaslice exposes the following Prometheus metrics:
+
+| Metric Name | Description |
+|-------------|-------------|
+| `instaslice_pod_processed_slices` | Tracks the number of pods that have been processed with their slice allocation. |
+| `instaslice_compatible_profiles` | Displays the profiles compatible with the remaining GPU slices on a node and their counts. |
+| `instaslice_total_processed_gpu_slices` | Counts the total processed GPU slices since the Instaslice controller started. |
+
+## Steps to Deploy Prometheus
+
+1. **Install Prometheus using Helm:**
+   ```sh
+   helm install prometheus -f deploy/prometheus.yaml prometheus-community/kube-prometheus-stack --namespace=instaslice-monitoring --create-namespace
+   ```
+2. **Apply Prometheus role and role binding:**
+   ```sh
+   kubectl apply -f deploy/prometheus-role.yaml
+   kubectl apply -f deploy/prometheus-rolebinding.yaml
+   ```
+3. **Apply the Instaslice ServiceMonitor:**
+   ```sh
+   kubectl apply -f deploy/instaslice-servicemonitor.yaml
+   ```
+
+## Deploy Instaslice and Configure Metrics Service
+
+1. **Apply the Instaslice Metrics Service YAML:**
+   ```sh
+   kubectl apply -f deploy/instaslice-metrics-service.yaml
+   ```
+2. **Check the readiness of Prometheus pods:**
+   ```sh
+   kubectl get pods -n instaslice-monitoring --watch
+   ```
+3. **Retrieve the token to access the service:**
+   ```sh
+   TOKEN=$(kubectl exec -it prometheus-prometheus-kube-prometheus-prometheus-0 -n instaslice-monitoring -- cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+   ```
+4. **Forward the Instaslice Metrics Service port:**
+   ```sh
+   kubectl port-forward svc/instaslice-metrics 8443:8443 -n instaslice-system
+   ```
+5. **Verify the exposed metrics using curl:**
+   ```sh
+   curl -k -H "Authorization: Bearer $TOKEN" https://localhost:8443/metrics
+   ```
+6. **Forward the Prometheus UI port for monitoring:**
+   ```sh
+   kubectl port-forward svc/prometheus-kube-prometheus-prometheus -n instaslice-monitoring 9090:9090
+   ```
+
+## Future Work
+- **Controller Failure Handling:** Additional fault tolerance mechanisms will be integrated to ensure resilience in case of failures.
+- **E2E Testing:** While unit tests are already in place, future efforts will focus on adding **end-to-end (E2E) tests** for Instaslice metrics.
+
+By following the above steps, Instaslice metrics can be successfully monitored using Prometheus. Future improvements will focus on increasing robustness and automated testing coverage.
+

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"fmt"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+)
+
+// calculateProfileFitOnGPU handles both profile simulation fit and actual allocation size
+// simulate - `true` → simulate fits | `false` → check actual allocation
+func (r *InstasliceReconciler) calculateProfileFitOnGPU(instaslice *inferencev1alpha1.Instaslice, profileName, gpuUUID string, simulate bool, pod *v1.Pod) (int32, error) {
+	// Get the GPU allocation state (already allocated slices)
+	originalAllocatedIndex := r.gpuAllocatedSlices(gpuUUID)
+	// Create a copy of the allocated slots (fixed-size array)
+	var gpuAllocatedIndex [8]int32
+	copy(gpuAllocatedIndex[:], originalAllocatedIndex[:]) // Ensure we don’t modify real allocations
+	// Determine the required slice size for this profile
+	var neededContinuousSlot int32
+	placement, exists := instaslice.Status.NodeResources.MigPlacement[profileName]
+	if !exists || len(placement.Placements) == 0 {
+		return 0, fmt.Errorf("profile %s not found in MigPlacement", profileName)
+	}
+	neededContinuousSlot = placement.Placements[0].Size
+	// If we're checking actual allocation, count and return immediately
+	if !simulate {
+		actualSliceSize := int32(0)
+		startIdx := r.getStartIndexFromAllocationResults(instaslice, profileName, gpuAllocatedIndex, &pod.UID, false)
+		for i := int32(0); i < neededContinuousSlot; i++ {
+			if startIdx+i < int32(len(originalAllocatedIndex)-1) {
+				actualSliceSize++
+			}
+		}
+		return actualSliceSize, nil // Return the **actual** allocated slice count
+	}
+	// If we are simulating, count how many times the profile **could fit**
+	fitCount := int32(0)
+	for i := 0; i < len(originalAllocatedIndex); i++ {
+		startIdx := r.getStartIndexFromAllocationResults(instaslice, profileName, gpuAllocatedIndex, nil, true)
+		// If no valid placement found, break the loop
+		if startIdx == 9 {
+			break
+		}
+		// Simulate allocation by marking the slots
+		for i := int32(0); i < neededContinuousSlot; i++ {
+			if startIdx+i < int32(len(gpuAllocatedIndex)) {
+				gpuAllocatedIndex[startIdx+i] = 1
+			}
+		}
+		fitCount++ // one successful fit
+	}
+	return fitCount, nil // total hypothetical fits
+}

--- a/internal/controller/prometheus_manager.go
+++ b/internal/controller/prometheus_manager.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023, 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type InstasliceMetrics struct {
+	compatibleProfiles *prometheus.GaugeVec
+	processedSlices    *prometheus.GaugeVec
+	deployedPodTotal   *prometheus.GaugeVec
+}
+
+var (
+	instasliceMetrics = &InstasliceMetrics{
+		// deployed pod total
+		deployedPodTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_pod_processed_slices",
+			Help: "Pods that are processed with their slice/s allocation.",
+		},
+			[]string{"node", "gpu_id", "namespace", "podname", "profile"}), // Labels: node, GPU ID, namespace, podname, profile
+		// compatible profiles with remaining gpu slices
+		compatibleProfiles: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_compatible_profiles",
+			Help: "Profiles compatible with remaining GPU slices in a node and their counts.",
+		},
+			[]string{"profile", "node"}), // Labels: profile, node
+		// total processed slices
+		processedSlices: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "instaslice_total_processed_gpu_slices",
+			Help: "Number of total processed GPU slices since instaslice controller start time.",
+		},
+			[]string{"node", "gpu_id"}), // Labels: node, GPU ID
+	}
+)
+
+// RegisterMetrics registers all Prometheus metrics
+func RegisterMetrics() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(instasliceMetrics.compatibleProfiles, instasliceMetrics.processedSlices, instasliceMetrics.deployedPodTotal)
+}
+
+// UpdateGpuSliceMetrics updates GPU slice allocation metrics
+func (r *InstasliceReconciler) IncrementTotalProcessedGpuSliceMetrics(instasliceObj inferencev1alpha1.Instaslice, nodeName, gpuID string, profile string, pod *v1.Pod) error {
+	processedSlices, err := r.calculateProfileFitOnGPU(&instasliceObj, profile, gpuID, false, pod)
+	if err != nil {
+		return fmt.Errorf("failed to calculate processed GPU slices for profile %s: %w", profile, err)
+	}
+	instasliceMetrics.processedSlices.WithLabelValues(nodeName, gpuID).Add(float64(processedSlices))
+	return nil
+}
+
+// UpdateGpuSliceMetrics updates GPU slice allocation metrics
+func (r *InstasliceReconciler) UpdateDeployedPodTotalMetrics(nodeName, gpuID, namespace, podname, profile string, size int32) error {
+	if namespace == "" && podname == "" && profile == "" {
+		return fmt.Errorf("[UpdateDeployedPodTotalMetrics] : missing required parameters, no prometheus update needed")
+	}
+	instasliceMetrics.deployedPodTotal.WithLabelValues(
+		nodeName, gpuID, namespace, podname, profile).Set(float64(size))
+	return nil
+}
+
+// UpdateCompatibleProfilesMetrics updates metrics based on remaining GPU slices and calculates compatible profiles dynamically
+// TODO: store metrics per gpu and when there is an update, calculate a fit for only one GPU instead of all GPUs on the host
+func (r *InstasliceReconciler) UpdateCompatibleProfilesMetrics(instasliceObj inferencev1alpha1.Instaslice, nodeName string) error {
+	sortedGPUs := sortGPUs(&instasliceObj)
+	// Iterate over each profile
+	for profileName, migPlacement := range instasliceObj.Status.NodeResources.MigPlacement {
+		if len(migPlacement.Placements) > 0 {
+			totalFit := int32(0)
+			// Iterate over all available GPUs
+			for _, gpuID := range sortedGPUs {
+				fit, err := r.calculateProfileFitOnGPU(&instasliceObj, profileName, gpuID, true, nil)
+				if err != nil {
+					return fmt.Errorf("failed to calculate compatible profiles for profile %s: %w", profileName, err)
+				}
+				totalFit += fit
+			}
+			// Update Prometheus metrics
+			instasliceMetrics.compatibleProfiles.WithLabelValues(profileName, nodeName).Set(float64(totalFit))
+		}
+	}
+	return nil
+}

--- a/internal/controller/prometheus_manager_test.go
+++ b/internal/controller/prometheus_manager_test.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Instaslice Controller", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		r          *InstasliceReconciler
+		instaslice *inferencev1alpha1.Instaslice
+		pod        *v1.Pod
+		podUUID    string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		Expect(inferencev1alpha1.AddToScheme(scheme)).To(Succeed())
+		Expect(v1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		r = &InstasliceReconciler{
+			Client: fakeClient,
+		}
+
+		podUUID = "test-pod-uuid"
+
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: InstaSliceOperatorNamespace,
+				UID:       types.UID(podUUID),
+				Finalizers: []string{
+					FinalizerName,
+				},
+			},
+		}
+
+		Expect(fakeClient.Create(ctx, pod)).To(Succeed())
+
+		instaslice = &inferencev1alpha1.Instaslice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-instaslice",
+				Namespace: InstaSliceOperatorNamespace,
+			},
+			Spec: inferencev1alpha1.InstasliceSpec{
+				PodAllocationRequests: map[types.UID]inferencev1alpha1.AllocationRequest{
+					types.UID(podUUID): {
+						Profile: "1g.5gb",
+						PodRef: v1.ObjectReference{
+							Name:      pod.Name,
+							Namespace: InstaSliceOperatorNamespace,
+							UID:       pod.UID,
+						},
+						Resources: v1.ResourceRequirements{},
+					},
+				},
+			},
+			Status: inferencev1alpha1.InstasliceStatus{
+				PodAllocationResults: map[types.UID]inferencev1alpha1.AllocationResult{
+					types.UID(podUUID): {
+						AllocationStatus:            inferencev1alpha1.AllocationStatus{AllocationStatusController: inferencev1alpha1.AllocationStatusCreating},
+						GPUUUID:                     "GPU-12345",
+						Nodename:                    "fake-node",
+						ConfigMapResourceIdentifier: "fake-configmap-uid",
+					},
+				},
+				// ✅ Ensure MigPlacement has the correct profile
+				NodeResources: inferencev1alpha1.DiscoveredNodeResources{
+					MigPlacement: map[string]inferencev1alpha1.Mig{
+						"1g.5gb": {
+							Placements: []inferencev1alpha1.Placement{
+								{Size: 1, Start: 0}, // Example placement
+							},
+						},
+						"1g.10gb": { // Also add the missing profile from the failing test
+							Placements: []inferencev1alpha1.Placement{
+								{Size: 2, Start: 0},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(fakeClient.Create(ctx, instaslice)).To(Succeed())
+	})
+
+	// Test IncrementTotalProcessedGpuSliceMetrics
+	It("should increment total processed GPU slice metrics", func() {
+		err := r.IncrementTotalProcessedGpuSliceMetrics(*instaslice, "node-1", "gpu-1", "1g.5gb", pod)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Test UpdateDeployedPodTotalMetrics
+	It("should update deployed pod total metrics", func() {
+		err := r.UpdateDeployedPodTotalMetrics("node-1", "gpu-1", "namespace-1", "pod-1", "profile-1", 2)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Test UpdateCompatibleProfilesMetrics
+	It("should update compatible profiles metrics", func() {
+		instaslice := inferencev1alpha1.Instaslice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "instaslice-1",
+				Namespace: "default",
+			},
+		}
+		err := r.UpdateCompatibleProfilesMetrics(instaslice, "node-1")
+		Expect(err).ToNot(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Addresses - https://github.com/openshift/instaslice-operator/issues/53
Enable Kubernetes metrics from controllers
And add Custom metrics
- _instaslice_pod_processed_slices_: Pods that are processed with their slice/s allocation
- _instaslice_compatible_profiles_: Profiles compatible with remaining GPU slices in a node and their counts
- _instaslice_total_processed_gpu_slices_ : Number of total processed GPU slices since instaslice controller start time

- [x] Unit tests added for metrics reconcile funcs and calls in instaslice _controller and prometheus_manager

- [x] **Updated**: Successful run of make test, make lint, make test-e2e, and make test-e2e-kind-emulated