### PR TITLE
added make targets for dependencies of e2e tests on ocp

### DIFF
--- a/hack/manifests/cert-manager-rh.yaml
+++ b/hack/manifests/cert-manager-rh.yaml
@@ -20,10 +20,9 @@ metadata:
   name: openshift-cert-manager-operator
   namespace: cert-manager-operator
 spec:
-  channel: stable-v1.14
+  channel: stable-v1
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
-  startingCSV: cert-manager-operator.v1.14.1
 

--- a/hack/manifests/gpu-cluster-policy.yaml
+++ b/hack/manifests/gpu-cluster-policy.yaml
@@ -1,0 +1,102 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  daemonsets:
+    rollingUpdate:
+      maxUnavailable: "1"
+    updateStrategy: RollingUpdate
+  dcgm:
+    enabled: true
+  dcgmExporter:
+    config:
+      name: ""
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  devicePlugin:
+    config:
+      default: ""
+      name: ""
+    enabled: false
+    mps:
+      root: /run/nvidia/mps
+  driver:
+    certConfig:
+      name: ""
+    enabled: true
+    kernelModuleConfig:
+      name: ""
+    licensingConfig:
+      configMapName: ""
+      nlsEnabled: true
+    repoConfig:
+      configMapName: ""
+    upgradePolicy:
+      autoUpgrade: true
+      drain:
+        deleteEmptyDir: false
+        enable: false
+        force: false
+        timeoutSeconds: 300
+      maxParallelUpgrades: 1
+      maxUnavailable: 25%
+      podDeletion:
+        deleteEmptyDir: false
+        force: false
+        timeoutSeconds: 300
+      waitForCompletion:
+        timeoutSeconds: 0
+    useNvidiaDriverCRD: false
+    useOpenKernelModules: false
+    virtualTopology:
+      config: ""
+  gdrcopy:
+    enabled: false
+  gds:
+    enabled: false
+  gfd:
+    enabled: true
+  mig:
+    strategy: mixed
+  migManager:
+    config:
+      default: ""
+      name: default-mig-parted-config
+    enabled: true
+    env:
+      - name: WITH_REBOOT
+        value: 'true'
+      - name: MIG_PARTED_MODE_CHANGE_ONLY
+        value: 'true'    
+  nodeStatusExporter:
+    enabled: true
+  operator:
+    defaultRuntime: crio
+    initContainer: {}
+    runtimeClass: nvidia
+    use_ocp_driver_toolkit: true
+  sandboxDevicePlugin:
+    enabled: true
+  sandboxWorkloads:
+    defaultWorkload: container
+    enabled: false
+  toolkit:
+    enabled: true
+    installDir: /usr/local/nvidia
+  validator:
+    plugin:
+      env:
+      - name: WITH_WORKLOAD
+        value: "false"
+    cuda:
+      env:
+      - name: WITH_WORKLOAD
+        value: "false"
+  vfioManager:
+    enabled: true
+  vgpuDeviceManager:
+    enabled: true
+  vgpuManager:
+    enabled: false

--- a/hack/manifests/nfd-instance.yaml
+++ b/hack/manifests/nfd-instance.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+items:
+- apiVersion: nfd.openshift.io/v1
+  kind: NodeFeatureDiscovery
+  metadata:
+    name: nfd-instance
+    namespace: openshift-nfd
+  spec:
+    enableTaints: false
+    instance: ""
+    operand:
+      imagePullPolicy: IfNotPresent
+      servicePort: 12000
+    prunerOnDelete: false
+    topologyUpdater: false
+    workerConfig:
+      configData: "core:\n#  labelWhiteList:\n#  noPublish: false\n  sleepInterval:
+        60s\n#  sources: [all]\n#  klog:\n#    addDirHeader: false\n#    alsologtostderr:
+        false\n#    logBacktraceAt:\n#    logtostderr: true\n#    skipHeaders: false\n#
+        \   stderrthreshold: 2\n#    v: 0\n#    vmodule:\n##   NOTE: the following
+        options are not dynamically run-time \n##          configurable and require
+        a nfd-worker restart to take effect\n##          after being changed\n#    logDir:\n#
+        \   logFile:\n#    logFileMaxSize: 1800\n#    skipLogHeaders: false\nsources:\n#
+        \ cpu:\n#    cpuid:\n##     NOTE: whitelist has priority over blacklist\n#
+        \     attributeBlacklist:\n#        - \"BMI1\"\n#        - \"BMI2\"\n#        -
+        \"CLMUL\"\n#        - \"CMOV\"\n#        - \"CX16\"\n#        - \"ERMS\"\n#
+        \       - \"F16C\"\n#        - \"HTT\"\n#        - \"LZCNT\"\n#        - \"MMX\"\n#
+        \       - \"MMXEXT\"\n#        - \"NX\"\n#        - \"POPCNT\"\n#        -
+        \"RDRAND\"\n#        - \"RDSEED\"\n#        - \"RDTSCP\"\n#        - \"SGX\"\n#
+        \       - \"SSE\"\n#        - \"SSE2\"\n#        - \"SSE3\"\n#        - \"SSE4.1\"\n#
+        \       - \"SSE4.2\"\n#        - \"SSSE3\"\n#      attributeWhitelist:\n#
+        \ kernel:\n#    kconfigFile: \"/path/to/kconfig\"\n#    configOpts:\n#      -
+        \"NO_HZ\"\n#      - \"X86\"\n#      - \"DMI\"\n  pci:\n    deviceClassWhitelist:\n
+        \     - \"0200\"\n      - \"03\"\n      - \"12\"\n    deviceLabelFields:\n#
+        \     - \"class\"\n      - \"vendor\"\n#      - \"device\"\n#      - \"subsystem_vendor\"\n#
+        \     - \"subsystem_device\"\n#  usb:\n#    deviceClassWhitelist:\n#      -
+        \"0e\"\n#      - \"ef\"\n#      - \"fe\"\n#      - \"ff\"\n#    deviceLabelFields:\n#
+        \     - \"class\"\n#      - \"vendor\"\n#      - \"device\"\n#  custom:\n#
+        \   - name: \"my.kernel.feature\"\n#      matchOn:\n#        - loadedKMod:
+        [\"example_kmod1\", \"example_kmod2\"]\n#    - name: \"my.pci.feature\"\n#
+        \     matchOn:\n#        - pciId:\n#            class: [\"0200\"]\n#            vendor:
+        [\"15b3\"]\n#            device: [\"1014\", \"1017\"]\n#        - pciId :\n#
+        \           vendor: [\"8086\"]\n#            device: [\"1000\", \"1100\"]\n#
+        \   - name: \"my.usb.feature\"\n#      matchOn:\n#        - usbId:\n#          class:
+        [\"ff\"]\n#          vendor: [\"03e7\"]\n#          device: [\"2485\"]\n#
+        \       - usbId:\n#          class: [\"fe\"]\n#          vendor: [\"1a6e\"]\n#
+        \         device: [\"089a\"]\n#    - name: \"my.combined.feature\"\n#      matchOn:\n#
+        \       - pciId:\n#            vendor: [\"15b3\"]\n#            device: [\"1014\",
+        \"1017\"]\n#          loadedKMod : [\"vendor_kmod1\", \"vendor_kmod2\"]\n"
+kind: List
+metadata:
+  resourceVersion: ""

--- a/hack/manifests/nfd.yaml
+++ b/hack/manifests/nfd.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nfd
+  labels:
+    name: openshift-nfd
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-nfd-
+  name: openshift-nfd
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+  - openshift-nfd
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  channel: "stable"
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+

--- a/hack/manifests/nvidia-cpu-operator.yaml
+++ b/hack/manifests/nvidia-cpu-operator.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nvidia-gpu-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-gpu-operator-group
+  namespace: nvidia-gpu-operator
+spec:
+ targetNamespaces:
+ - nvidia-gpu-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  channel: "v24.9"
+  installPlanApproval: Automatic
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: "gpu-operator-certified.v24.9.2"
+
+


### PR DESCRIPTION
This is the foundation of the prow job for e2e.  Will use these targets to setup the test environment.  Also added targets to reverse everything cleanly.