### PR TITLE
add checks to deploy operator make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ undeploy-cert-manager-ocp:
 .PHONY: deploy-nfd-ocp
 deploy-nfd-ocp:
 	oc apply -f hack/manifests/nfd.yaml
+	oc wait --for condition=established --timeout=60s crd/nodefeaturediscoveries.nfd.openshift.io -n openshift-nfd
 	oc apply -f hack/manifests/nfd-instance.yaml
 	oc describe node | egrep 'Roles|pci' # check for at least on enabled node
 
@@ -258,6 +259,7 @@ undeploy-nfd-ocp:
 .PHONY: deploy-nvidia-ocp
 deploy-nvidia-ocp:
 	oc apply -f hack/manifests/nvidia-cpu-operator.yaml
+	oc wait --for condition=established --timeout=60s crd/clusterpolicies.nvidia.com
 	oc apply -f hack/manifests/gpu-cluster-policy.yaml
 	oc label $(shell oc get node -o name) nvidia.com/mig.config=all-enabled --overwrite
 	oc wait --for=condition=Ready pod -l app=nvidia-operator-validator  -n nvidia-gpu-operator --timeout=300s


### PR DESCRIPTION
CRDs need to exist before creating CRs in the make targets for deploying operators.  Added oc wait to make sure they do.

Testing instructions:
On any cluster, run the make targets.  They should create the CR without error.
make deploy-nfd-ocp
make deploy-nvidia-ocp (will ultimately fail if cluster does not have cpu hardware or missing deps but will install operator and CR)
