### PR TITLE
Decouple daemonset creation and move to setupwithmanager

### DIFF
--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -440,15 +440,6 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 				log.Error(err, "could not create fake capacity", "node_name", r.NodeName)
 				return err
 			}
-			//get metadata.resourceVersion
-			// for i := 1; i < 5; i++ {
-			// 	err := r.Get(ctx, typeNamespacedName, &instaslice)
-			// 	if err == nil {
-			// 		break
-			// 	}
-			// 	log.Error(err, "Retrying fetch fake capacity", "attempt", i+1, "node_name", r.NodeName)
-			// 	time.Sleep(2 * time.Second)
-			// }
 			err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 				err = r.Get(ctx, typeNamespacedName, &instaslice)
 				if err == nil {
@@ -471,7 +462,6 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 				return err
 			}
 			// let the update propagate
-			// time.Sleep(2 * time.Second)
 			err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 				err = r.Get(ctx, typeNamespacedName, &instaslice)
 				if err != nil {

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -61,6 +61,8 @@ type InstasliceReconciler struct {
 	RunningOnOpenShift bool
 	allocationCache    map[types.UID]inferencev1alpha1.AllocationResult
 	isCacheInitialized bool
+	// Optional override for testing
+	createDSFn func(namespace string) *appsv1.DaemonSet
 }
 
 // AllocationPolicy interface with a single method
@@ -94,7 +96,6 @@ var daemonSetlabel = map[string]string{"app": "controller-daemonset"}
 
 func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
-
 	if r.RunningOnOpenShift {
 		err := r.ReconcileSCC(ctx)
 		if err != nil {
@@ -102,66 +103,18 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 	}
-
-	// 1. Ensure DaemonSet is deployed
-	daemonSet := &appsv1.DaemonSet{}
-	err := r.Get(ctx, types.NamespacedName{Name: InstasliceDaemonsetName, Namespace: InstaSliceOperatorNamespace}, daemonSet)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// DaemonSet doesn't exist, so create it
-			daemonSet = r.createInstaSliceDaemonSet(InstaSliceOperatorNamespace)
-			err = r.Create(ctx, daemonSet)
-			if err != nil {
-				log.Error(err, "Failed to create DaemonSet")
-				return ctrl.Result{RequeueAfter: time.Minute}, err
-			}
-			log.Info("DaemonSet created successfully, waiting for pods to be ready")
-			return ctrl.Result{RequeueAfter: requeue10sDelay}, nil
-		}
-		log.Error(err, "Failed to get DaemonSet")
-		return ctrl.Result{RequeueAfter: time.Minute}, err
-	}
-
-	// 2. Check if at least one DaemonSet pod is ready
-	var podList v1.PodList
-	labelSelector := labels.SelectorFromSet(daemonSet.Spec.Selector.MatchLabels)
-
-	listOptions := &client.ListOptions{
-		LabelSelector: labelSelector,
-		Namespace:     InstaSliceOperatorNamespace,
-	}
-
-	if err := r.List(ctx, &podList, listOptions); err != nil {
-		log.Error(err, "Failed to list DaemonSet pods")
-		return ctrl.Result{RequeueAfter: time.Minute}, err
-	}
-
-	// Check if at least one daemonset pod is ready
-	isAnyPodReady := false
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == v1.PodRunning && len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
-			isAnyPodReady = true
-			break
-		}
-	}
-	if daemonSet.Status.NumberReady == 0 && !isAnyPodReady {
-		log.Info("No DaemonSet pods are ready yet, waiting...")
-		return ctrl.Result{RequeueAfter: requeue10sDelay}, nil
-	}
 	// TODO: should we rebuild cache on node failure?
-
-	// Continue with the rest of the reconciliation logic
 	policy := &FirstFitPolicy{}
 	pod := &v1.Pod{}
 	var instasliceList inferencev1alpha1.InstasliceList
-	if err = r.List(ctx, &instasliceList, &client.ListOptions{}); err != nil {
+	if err := r.List(ctx, &instasliceList, &client.ListOptions{}); err != nil {
 		log.Error(err, "Error getting Instaslice object")
 		return ctrl.Result{}, err
 	}
 	for _, instaslice := range instasliceList.Items {
 		// Get the node object on which the instaslice object is present
 		node := &v1.Node{}
-		if err = r.Get(ctx, client.ObjectKey{Name: instaslice.Name}, node); err != nil {
+		if err := r.Get(ctx, client.ObjectKey{Name: instaslice.Name}, node); err != nil {
 			log.Error(err, "error getting the node object", "name", instaslice.Name)
 			return ctrl.Result{RequeueAfter: 1 * time.Second}, err
 		}
@@ -172,7 +125,7 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	err = r.Get(ctx, req.NamespacedName, pod)
+	err := r.Get(ctx, req.NamespacedName, pod)
 	if err != nil {
 		// Error fetching the Pod
 		if errors.IsNotFound(err) {
@@ -488,6 +441,151 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
+// Initialize Prometheus-compatible profiles metrics when the controller starts
+// Adds a background goroutine that waits for Instaslice objects.
+// Proceeds to setupWithManager(mgr) to start the reconciler
+// Does not block the controller from reconciling
+// UpdateCompatibleProfilesMetrics only updates Prometheus metrics,in-memory and do not persist in etcd
+// TODO: support daemonset fault tolerance and controller fault tolerance (skipping an update for a faster boot)
+func (r *InstasliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	restConfig := mgr.GetConfig()
+	var err error
+	r.kubeClient, err = kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	mgrAddErr := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		log := logr.FromContext(ctx)
+		<-mgr.Elected() // Wait for leader election before executing
+		// ensure daemonset creation with retry mechanism
+		retryErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			if err := r.ensureDaemonSetExists(ctx); err != nil {
+				log.Error(err, "Retrying DaemonSet creation")
+				return false, nil
+			}
+			return true, nil
+		})
+		if retryErr != nil {
+			log.Error(retryErr, "Failed to create DaemonSet after retries")
+			return nil
+		}
+		daemonSet := &appsv1.DaemonSet{}
+		err = r.Get(ctx, types.NamespacedName{Name: InstasliceDaemonsetName, Namespace: InstaSliceOperatorNamespace}, daemonSet)
+		if err == nil {
+			readinessErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+				return r.isDaemonSetPodReady(ctx, daemonSet)
+			})
+			if readinessErr != nil {
+				log.Error(readinessErr, "Timeout waiting for DaemonSet pod readiness")
+				return readinessErr
+			}
+			log.Info("At least one DaemonSet pod is ready")
+		}
+		// Retry mechanism to wait for Instaslice objects
+		var instasliceList inferencev1alpha1.InstasliceList
+		retryErr = wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+			if err := r.List(ctx, &instasliceList); err != nil {
+				log.Error(err, "Failed to list Instaslice objects, retrying...")
+				return false, nil
+			}
+			if len(instasliceList.Items) > 0 {
+				log.Info("Instaslice objects found", "count", len(instasliceList.Items))
+				return true, nil
+			}
+			log.Info("No Instaslice objects found, waiting...")
+			return false, nil
+		})
+		if retryErr != nil {
+			log.Error(retryErr, "Failed to fetch Instaslice objects after retries")
+			return nil // Do not block the controller from running, meaning reconciler starts in parallel
+		}
+		// Iterate over Instaslices and update Prometheus metrics
+		for _, instaslice := range instasliceList.Items {
+			r.UpdateCompatibleProfilesMetrics(instaslice, instaslice.Name)
+		}
+		log.Info("Successfully initialized compatible profiles metrics for all Instaslice objects")
+		return nil
+	}))
+
+	if mgrAddErr != nil {
+		return mgrAddErr
+	}
+
+	// Continue with setting up the controller
+	return r.setupWithManager(mgr) // Return error directly for readability
+}
+
+// Enable creation of controller
+func (r *InstasliceReconciler) setupWithManager(mgr ctrl.Manager) error {
+	restConfig := mgr.GetConfig()
+	var err error
+	r.kubeClient, err = kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+	err = ctrl.NewControllerManagedBy(mgr).
+		For(&v1.Pod{}).Named("InstaSlice-controller").
+		Watches(&inferencev1alpha1.Instaslice{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
+		Watches(&v1.Node{},
+			&handler.EnqueueRequestForObject{}).
+		Complete(r)
+
+	if err != nil {
+		log := mgr.GetLogger() // Get logger from the manager
+		log.Error(err, "Failed to set up Instaslice controller")
+		return err
+	}
+
+	log := mgr.GetLogger()
+	log.Info("Successfully set up Instaslice controller")
+	return nil
+}
+
+// ensureDaemonSetExists ensures the daamenset exists
+func (r *InstasliceReconciler) ensureDaemonSetExists(ctx context.Context) error {
+	log := logr.FromContext(ctx)
+	daemonSet := &appsv1.DaemonSet{}
+	err := r.Get(ctx, types.NamespacedName{Name: InstasliceDaemonsetName, Namespace: InstaSliceOperatorNamespace}, daemonSet)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			var newDS *appsv1.DaemonSet
+			if r.createDSFn != nil {
+				newDS = r.createDSFn(InstaSliceOperatorNamespace)
+			} else {
+				newDS = r.createInstaSliceDaemonSet(InstaSliceOperatorNamespace)
+			}
+
+			if err := r.Create(ctx, newDS); err != nil {
+				return err
+			}
+			log.Info("DaemonSet created successfully")
+			return nil
+		}
+		return err
+	}
+	log.Info("DaemonSet already exists")
+	return nil
+}
+
+// isDaemonSetPodReady - DaemonSet readiness check
+func (r *InstasliceReconciler) isDaemonSetPodReady(ctx context.Context, daemonSet *appsv1.DaemonSet) (bool, error) {
+	var podList v1.PodList
+	labelSelector := labels.SelectorFromSet(daemonSet.Spec.Selector.MatchLabels)
+	listOptions := &client.ListOptions{
+		LabelSelector: labelSelector,
+		Namespace:     daemonSet.Namespace,
+	}
+	if err := r.List(ctx, &podList, listOptions); err != nil {
+		return false, err
+	}
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == v1.PodRunning && len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // createInstaSliceDaemonSet - create the DaemonSet object
 func (r *InstasliceReconciler) createInstaSliceDaemonSet(namespace string) *appsv1.DaemonSet {
 	emulatorMode := r.Config.EmulatorModeEnable
@@ -562,7 +660,6 @@ func (r *InstasliceReconciler) createInstaSliceDaemonSet(namespace string) *apps
 			},
 		},
 	}
-
 	return daemonSet
 }
 
@@ -645,82 +742,6 @@ func (r *InstasliceReconciler) podMapFunc(ctx context.Context, obj client.Object
 		}
 	}
 	return requests
-}
-
-// Initialize Prometheus-compatible profiles metrics when the controller starts
-// Adds a background goroutine that waits for Instaslice objects.
-// Proceeds to setupWithManager(mgr) to start the reconciler
-// Does not block the controller from reconciling
-// UpdateCompatibleProfilesMetrics only updates Prometheus metrics,in-memory and do not persist in etcd
-// TODO: support daemonset fault tolerance and controller fault tolerance (skipping an update for a faster boot)
-func (r *InstasliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	restConfig := mgr.GetConfig()
-	var err error
-	r.kubeClient, err = kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-	mgrAddErr := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		log := logr.FromContext(ctx)
-		<-mgr.Elected() // Wait for leader election before executing
-		// Retry mechanism to wait for Instaslice objects
-		var instasliceList inferencev1alpha1.InstasliceList
-		retryErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
-			if err := r.List(ctx, &instasliceList); err != nil {
-				log.Error(err, "Failed to list Instaslice objects, retrying...")
-				return false, nil
-			}
-			if len(instasliceList.Items) > 0 {
-				log.Info("Instaslice objects found", "count", len(instasliceList.Items))
-				return true, nil
-			}
-			log.Info("No Instaslice objects found, waiting...")
-			return false, nil
-		})
-		if retryErr != nil {
-			log.Error(retryErr, "Failed to fetch Instaslice objects after retries")
-			return nil // Do not block the controller from running, meaning reconciler starts in parallel
-		}
-		// Iterate over Instaslices and update Prometheus metrics
-		for _, instaslice := range instasliceList.Items {
-			r.UpdateCompatibleProfilesMetrics(instaslice, instaslice.Name)
-		}
-		log.Info("Successfully initialized compatible profiles metrics for all Instaslice objects")
-		return nil
-	}))
-
-	if mgrAddErr != nil {
-		return mgrAddErr
-	}
-
-	// Continue with setting up the controller
-	return r.setupWithManager(mgr) // Return error directly for readability
-}
-
-// Enable creation of controller
-func (r *InstasliceReconciler) setupWithManager(mgr ctrl.Manager) error {
-	restConfig := mgr.GetConfig()
-	var err error
-	r.kubeClient, err = kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-	err = ctrl.NewControllerManagedBy(mgr).
-		For(&v1.Pod{}).Named("InstaSlice-controller").
-		Watches(&inferencev1alpha1.Instaslice{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
-		Watches(&v1.Node{},
-			&handler.EnqueueRequestForObject{}).
-		Complete(r)
-
-	if err != nil {
-		log := mgr.GetLogger() // Get logger from the manager
-		log.Error(err, "Failed to set up Instaslice controller")
-		return err
-	}
-
-	log := mgr.GetLogger()
-	log.Info("Successfully set up Instaslice controller")
-	return nil
 }
 
 func (r *InstasliceReconciler) unGatePod(podUpdate *v1.Pod) *v1.Pod {


### PR DESCRIPTION
### Why move DaemonSet creation into SetupWithManager
- Separation of concerns: Reconciliation should be idempotent and focused on instaslice reconciling runtime state.
- Avoid rechecking every reconcile loop: Currently, every Pod triggers a check for the DaemonSet even though it's cluster-wide.
- Improved efficiency: DaemonSet is needed once per cluster, not per reconcile loop.
- Safer control: Failing to create the DaemonSet can block controller start, which is usually preferred in infra boot-up.

Added unit tests, including checks for:
- DaemonSet with no pods → not ready
- DaemonSet with 1 non-ready pod → not ready
- DaemonSet with 1 ready pod → ready
- Skips creation if it already exists.

- [x] **Updated**: Successful run of make test, make lint, make test-e2e, and make test-e2e-kind-emulated