### PR TITLE
Add Pod filtering and webhook annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ $ oc new-project instaslice-system
 $ operator-sdk run bundle quay.io/ibm/instaslice-bundle:v0.0.2 -n instaslice-system
 ```
 
+### ⚠️ Required Webhook Setup for Mutation
+
+The mutation webhook uses a namespace selector, so **only namespaces labeled like below will be processed**:
+
+```bash
+kubectl label namespace <target-ns> instaslice.redhat.com/enable-mutation=true
+```
+
+For example:
+
+```bash
+kubectl label namespace default instaslice.redhat.com/enable-mutation=true
+```
+
+If this label is missing, pods in that namespace **will not be mutated**.
+
 ### Running a sample workload
 Please note that running a sample workload requires availability of compatible GPUs (nvidia A100, H100, H200) on the worker nodes.
 

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,6 +1,21 @@
 resources:
-- manifests.yaml
-- service.yaml
+  - manifests.yaml
+  - service.yaml
 
 configurations:
-- kustomizeconfig.yaml
+  - kustomizeconfig.yaml
+
+patches:
+  - patch: |-
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: MutatingWebhookConfiguration
+      metadata:
+        name: mutating-webhook-configuration
+      webhooks:
+        - name: instaslice.redhat.com
+          namespaceSelector:
+            matchLabels:
+              instaslice.redhat.com/enable-mutation: "true"
+    target:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -23,10 +23,12 @@ const (
 	GateName                         = OrgInstaslicePrefix + "accelerator"
 	FinalizerName                    = GateName
 	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
+	LabelInstasliceMutated           = OrgInstaslicePrefix + "mutated"
 	GPUMemoryLabelName               = "nvidia.com/gpu.memory"
 	GPUCountLabelName                = "nvidia.com/gpu.count"
 	EmulatorModeFalse                = "false"
 	EmulatorModeTrue                 = "true"
+	InstaslicePodMutatedTrue         = "true"
 	AttributeMediaExtensions         = "me"
 	InstaSliceOperatorNamespace      = "instaslice-system"
 	NvidiaMIGPrefix                  = "nvidia.com/mig-"

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -46,9 +46,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -523,9 +525,27 @@ func (r *InstasliceReconciler) setupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
+
+	// pod filtering
+	// only watches Pods that: have the mutation label
+	// Use event-based predicate with label checks and update detection
+	instaslicePredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object != nil && e.Object.GetLabels()[LabelInstasliceMutated] == InstaslicePodMutatedTrue
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return (e.ObjectNew != nil && e.ObjectNew.GetLabels()[LabelInstasliceMutated] == InstaslicePodMutatedTrue) ||
+				e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object != nil && e.Object.GetLabels()[LabelInstasliceMutated] == InstaslicePodMutatedTrue
+		},
+	}
+
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Pod{}).Named("InstaSlice-controller").
 		Watches(&inferencev1alpha1.Instaslice{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
+		WithEventFilter(instaslicePredicate).
 		Watches(&v1.Node{},
 			&handler.EnqueueRequestForObject{}).
 		Complete(r)

--- a/internal/controller/pod_webhook.go
+++ b/internal/controller/pod_webhook.go
@@ -80,6 +80,12 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 		},
 	})
 
+	// Add annotation, if pod mutated
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	pod.Labels[LabelInstasliceMutated] = "true"
+
 	// Marshal the updated pod object back to JSON
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {

--- a/internal/controller/pod_webhook_test.go
+++ b/internal/controller/pod_webhook_test.go
@@ -132,6 +132,7 @@ func TestHandle(t *testing.T) {
 				g.Expect(found).To(BeTrue(), fmt.Sprintf("%s limit not found in the modified pod", instasliceQuotaResourceName))
 				expectedMemory := resource.MustParse(tt.expectedLimit)
 				g.Expect(actualMemory.Cmp(expectedMemory)).To(Equal(0), fmt.Sprintf("Expected %s to be %s", instasliceQuotaResourceName, tt.expectedLimit))
+				g.Expect(modifiedPod.Labels).To(HaveKeyWithValue(LabelInstasliceMutated, "true"), "Expected mutated label to be added")
 			} else {
 				g.Expect(resp.Allowed).To(BeTrue(), "Expected request to be allowed without mutation")
 				g.Expect(resp.Patches).To(BeEmpty(), "Expected no patches but found some")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,6 +39,7 @@ import (
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -138,6 +139,16 @@ var _ = BeforeSuite(func() {
 	} else {
 		templateVars.NodeNames = []string{nodeNames[0]}
 	}
+
+	// add label to namespace default, only pods in namespace with label get processed
+	_, err = clientSet.CoreV1().Namespaces().Patch(ctx, "default", types.MergePatchType, []byte(`{
+		"metadata": {
+		  "labels": {
+			"instaslice.redhat.com/enable-mutation": "true"
+		  }
+		}
+	  }`), metav1.PatchOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Failed to label default namespace")
 
 	GinkgoWriter.Printf("cri-bin: %v\n", criBin)
 	GinkgoWriter.Printf("kubectl-bin: %v\n", kubectlBin)
@@ -269,6 +280,27 @@ var _ = Describe("controller", Ordered, func() {
 				"controller_runtime_reconcile_total",
 			))
 		})
+		It("should not mutate pods in an unlabeled namespace", func() {
+			_, err := clientSet.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-mutation-ns",
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			pod := resources.GetNoMutationPod()
+
+			err = k8sClient.Create(ctx, pod)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create the pod")
+
+			Consistently(func() string {
+				pod, _ := clientSet.CoreV1().Pods("no-mutation-ns").Get(ctx, "no-mutation-pod", metav1.GetOptions{})
+				if pod == nil {
+					return "MISSING"
+				}
+				return pod.Labels["instaslice.redhat.com/mutated"]
+			}, 10*time.Second, 2*time.Second).ShouldNot(Equal("true"), "Webhook should not mutate pod in unlabeled namespace")
+		})
+
 		It("should create a pod with no requests and check the allocation in instaslice object", func() {
 			pod := resources.GetVectorAddNoReqPod()
 			err := k8sClient.Create(ctx, pod)

--- a/test/e2e/resources/resource_generator.go
+++ b/test/e2e/resources/resource_generator.go
@@ -52,6 +52,30 @@ func GetVectorAddFinalizerPod() *corev1.Pod {
 	}
 }
 
+func GetNoMutationPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-mutation-pod",
+			Namespace: "no-mutation-ns",
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyOnFailure,
+			Containers: []corev1.Container{
+				{
+					Name:  "no-mutation-pod",
+					Image: "ubuntu:20.04",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"nvidia.com/mig-1g.5gb": resource.MustParse("1"),
+						},
+					},
+					Command: []string{"sh", "-c", "sleep 20"},
+				},
+			},
+		},
+	}
+}
+
 func GetVectorAddNoReqPod() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
- Pod filtering - only watches Pods that have a mutation annotation, or a meaningful Change
- enhance webhook - add annotation if pod is mutated

Namespaces need to have the following label for pods to be processed - _**instaslice.redhat.com/enable-mutation=true**_
- [x] Unit and e2e tests added

**Updated**: Successful run of:
- [x] make test
- [x] make lint
- [x] make test-e2e-kind-emulated
- [x] make test-e2e on kind cluster with GPUs
- [ ] make test-e2e on ocp cluster with GPUs [@sairameshv to test]