### PR TITLE
Clean up node object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ test-e2e-kind-emulated: export IMG_TAG=test-e2e
 test-e2e-kind-emulated: export KIND_NAME=kind-e2e
 test-e2e-kind-emulated: export KIND_CONTEXT=kind-kind-e2e
 test-e2e-kind-emulated: export KIND_NODE_NAME=${KIND_NAME}-control-plane
+test-e2e-kind-emulated: export AUTO_LABEL_MANAGED_NODES=true
 test-e2e-kind-emulated: export EMULATOR_MODE=true
 test-e2e-kind-emulated: docker-build docker-push create-kind-cluster deploy-cert-manager deploy-instaslice-emulated-on-kind
 	export KIND=$(KIND) KUBECTL=$(KUBECTL) IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
@@ -170,7 +171,7 @@ check-gpu-nodes:
 test-e2e-ocp-emulated: container-build-ocp docker-push bundle-ocp-emulated bundle-build-ocp bundle-push deploy-cert-manager-ocp deploy-instaslice-on-ocp
 	hack/label-node.sh
 	$(eval FOCUS_ARG := $(if $(FOCUS),--focus="$(FOCUS)"))
-	EMULATOR_MODE=true ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m $(FOCUS_ARG) ./test/e2e
+	EMULATOR_MODE=true AUTO_LABEL_MANAGED_NODES=true ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m $(FOCUS_ARG) ./test/e2e
 
 PHONY: cleanup-test-e2e-ocp-emulated
 cleanup-test-e2e-ocp-emulated: KUBECTL=oc
@@ -179,6 +180,7 @@ cleanup-test-e2e-ocp-emulated: ocp-undeploy-emulated
 .PHONY: test-e2e-ocp
 test-e2e-ocp: wait-for-instaslice-operator-stable
 test-e2e-ocp: export EMULATOR_MODE=false
+test-e2e-ocp: export AUTO_LABEL_MANAGED_NODES=true
 test-e2e-ocp:
 	$(eval FOCUS_ARG := $(if $(FOCUS),--focus="$(FOCUS)"))
 	ginkgo -v --json-report=report.json --junit-report=report.xml --timeout 20m $(FOCUS_ARG) ./test/e2e

--- a/README.md
+++ b/README.md
@@ -49,6 +49,39 @@ $ oc new-project instaslice-system
 $ operator-sdk run bundle quay.io/ibm/instaslice-bundle:v0.0.2 -n instaslice-system
 ```
 
+### Node Management Label
+
+InstaSlice now manages only nodes explicitly labeled with:
+
+```bash
+instaslice.redhat.com/managed=true
+```
+
+To enable management of a node by InstaSlice:
+
+```bash
+kubectl label node <node-name> instaslice.redhat.com/managed=true
+```
+
+To opt-out a node from InstaSlice management:
+
+```bash
+kubectl label node <node-name> instaslice.redhat.com/managed-
+```
+
+### Optional: Auto-Labeling Nodes
+
+You can enable automatic labeling of all MIG-capable nodes at operator startup using the following environment variable:
+
+```yaml
+- name: AUTO_LABEL_MANAGED_NODES
+  value: "true"
+```
+
+This can be configured in your controller Deployment. When enabled:
+- Nodes with `nvidia.com/mig.capable=true` will automatically be labeled as managed.
+- Disabled by default to preserve admin control.
+
 ### Running a sample workload
 Please note that running a sample workload requires availability of compatible GPUs (nvidia A100, H100, H200) on the worker nodes.
 

--- a/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/instaslice-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Basic Install
     categories: Drivers and plugins
     containerImage: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c4989eed5cf6ed63240d937727d258cb1cf862b371f5f1b3c4010b5f96196ead
-    createdAt: "2025-02-20T14:30:16Z"
+    createdAt: "2025-05-07T21:45:55Z"
     description: InstaSlice works with GPU operator to create mig slices on demand
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -340,7 +340,9 @@ spec:
                 - name: RELATED_IMAGE_INSTASLICE_DAEMONSET
                   value: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:2552d54ebcc0c00eb821581da3e2416621946a53232eb0cdbf0b91ee96267ae7
                 - name: EMULATOR_MODE
-                  value: "true"
+                  value: "false"
+                - name: AUTO_LABEL_MANAGED_NODES
+                  value: "false"
                 image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:c4989eed5cf6ed63240d937727d258cb1cf862b371f5f1b3c4010b5f96196ead
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/emulator/controller-with-emulator.yaml
+++ b/config/emulator/controller-with-emulator.yaml
@@ -11,3 +11,5 @@ spec:
           env:
             - name: EMULATOR_MODE
               value: "true"
+            - name: AUTO_LABEL_MANAGED_NODES
+              value: "true"

--- a/config/manager-ocp/manager.yaml
+++ b/config/manager-ocp/manager.yaml
@@ -104,5 +104,8 @@ spec:
             value: <IMG_DMST>
           - name: EMULATOR_MODE
             value: "false"
+          - name: AUTO_LABEL_MANAGED_NODES
+            value: "false"
+
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	DefaultEmulatorMode = false
-	DefaultWebhookMode  = true
+	DefaultEmulatorMode          = false
+	DefaultWebhookMode           = true
+	DefaultAutoLabelManagedNodes = false
 	// TODO fix this image
 	DefaultDaemonsetImage    = "quay.io/amalvank/instaslicev2-daemonset:latest"
 	DefaultManifestConfigDir = "/config"
@@ -26,14 +27,18 @@ type Config struct {
 
 	// ManifestConfigDir manifest directory
 	ManifestConfigDir string `json:"manifest_config_dir"`
+
+	// AutoLabelManagedNodes automatically labels mig capable nodes with "instaslice.redhat.com/managed "at daemonset startup
+	AutoLabelManagedNodes bool `json:"auto_label_managed_nodes"`
 }
 
 func NewConfig() *Config {
 	return &Config{
-		EmulatorModeEnable: DefaultEmulatorMode,
-		WebhookEnable:      DefaultWebhookMode,
-		DaemonsetImage:     DefaultDaemonsetImage,
-		ManifestConfigDir:  DefaultManifestConfigDir,
+		EmulatorModeEnable:    DefaultEmulatorMode,
+		WebhookEnable:         DefaultWebhookMode,
+		DaemonsetImage:        DefaultDaemonsetImage,
+		ManifestConfigDir:     DefaultManifestConfigDir,
+		AutoLabelManagedNodes: DefaultAutoLabelManagedNodes,
 	}
 }
 
@@ -59,6 +64,10 @@ func ConfigFromEnvironment() *Config {
 
 	if manifestConfigDir, ok := os.LookupEnv("MANIFEST_CONFIG_DIR"); ok {
 		config.ManifestConfigDir = manifestConfigDir
+	}
+
+	if autoLabel, ok := os.LookupEnv("AUTO_LABEL_MANAGED_NODES"); ok {
+		config.AutoLabelManagedNodes = strings.EqualFold(autoLabel, "true")
 	}
 
 	return config

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -20,6 +20,7 @@ import "time"
 
 const (
 	OrgInstaslicePrefix              = "instaslice.redhat.com/"
+	managedLabel                     = OrgInstaslicePrefix + "managed"
 	GateName                         = OrgInstaslicePrefix + "accelerator"
 	FinalizerName                    = GateName
 	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
@@ -27,6 +28,8 @@ const (
 	GPUCountLabelName                = "nvidia.com/gpu.count"
 	EmulatorModeFalse                = "false"
 	EmulatorModeTrue                 = "true"
+	InstasliceManagedTrue            = "true"
+	MigCapableTrue                   = "true"
 	AttributeMediaExtensions         = "me"
 	InstaSliceOperatorNamespace      = "instaslice-system"
 	NvidiaMIGPrefix                  = "nvidia.com/mig-"

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -89,8 +89,8 @@ func UpdateOrDeleteInstasliceAllocations(ctx context.Context, kubeClient client.
 	}
 	err = kubeClient.Status().Patch(ctx, &newInstaslice, client.MergeFrom(originalInstaSliceObj)) // TODO - try with update
 	if err != nil {
-		log.FromContext(ctx).Info("error patching allocation result ", err, "pod uuid", allocRequest.PodRef.UID)
-		return fmt.Errorf("error updating the instaslie object status, %s, err: %v", name, err)
+		log.FromContext(ctx).Info("error patching allocation result", "error", err, "pod uuid", allocRequest.PodRef.UID)
+		return fmt.Errorf("error updating the instaslice object status, %s, err: %v", name, err)
 	}
 	return nil
 }


### PR DESCRIPTION
- Takes care of - https://github.com/openshift/instaslice-operator/issues/550
- Prevents orphaned Instaslice CRs when a Node is taken away from instaslice or becomes non-MIG capable
- Cleans up custom resource requests properly from nodes not managed by instaslice anymore

- [x] Unit tests added

**Updated**: Successful run of:
- [x] make test
- [x] make lint
- [x] make test-e2e-kind-emulated
- [x] make test-e2e on kind cluster with GPUs
- [ ] make test-e2e on ocp cluster with GPUs [@sairameshv to test]