### PR TITLE
Revert "Add Pod filtering and webhook annotation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,22 +49,6 @@ $ oc new-project instaslice-system
 $ operator-sdk run bundle quay.io/ibm/instaslice-bundle:v0.0.2 -n instaslice-system
 ```
 
-### ⚠️ Required Webhook Setup for Mutation
-
-The mutation webhook uses a namespace selector, so **only namespaces labeled like below will be processed**:
-
-```bash
-kubectl label namespace <target-ns> instaslice.redhat.com/enable-mutation=true
-```
-
-For example:
-
-```bash
-kubectl label namespace default instaslice.redhat.com/enable-mutation=true
-```
-
-If this label is missing, pods in that namespace **will not be mutated**.
-
 ### Running a sample workload
 Please note that running a sample workload requires availability of compatible GPUs (nvidia A100, H100, H200) on the worker nodes.
 

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,21 +1,6 @@
 resources:
-  - manifests.yaml
-  - service.yaml
+- manifests.yaml
+- service.yaml
 
 configurations:
-  - kustomizeconfig.yaml
-
-patches:
-  - patch: |-
-      apiVersion: admissionregistration.k8s.io/v1
-      kind: MutatingWebhookConfiguration
-      metadata:
-        name: mutating-webhook-configuration
-      webhooks:
-        - name: instaslice.redhat.com
-          namespaceSelector:
-            matchLabels:
-              instaslice.redhat.com/enable-mutation: "true"
-    target:
-      kind: MutatingWebhookConfiguration
-      name: mutating-webhook-configuration
+- kustomizeconfig.yaml

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -23,12 +23,10 @@ const (
 	GateName                         = OrgInstaslicePrefix + "accelerator"
 	FinalizerName                    = GateName
 	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
-	LabelInstasliceMutated           = OrgInstaslicePrefix + "mutated"
 	GPUMemoryLabelName               = "nvidia.com/gpu.memory"
 	GPUCountLabelName                = "nvidia.com/gpu.count"
 	EmulatorModeFalse                = "false"
 	EmulatorModeTrue                 = "true"
-	InstaslicePodMutatedTrue         = "true"
 	AttributeMediaExtensions         = "me"
 	InstaSliceOperatorNamespace      = "instaslice-system"
 	NvidiaMIGPrefix                  = "nvidia.com/mig-"

--- a/internal/controller/instaslice_controller_test.go
+++ b/internal/controller/instaslice_controller_test.go
@@ -28,15 +28,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	inferencev1alpha1 "github.com/openshift/instaslice-operator/api/v1alpha1"
@@ -176,54 +173,6 @@ var _ = Describe("ensureDaemonSetExists", func() {
 		}
 		err := reconciler.ensureDaemonSetExists(ctx)
 		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("Instaslice Predicate", func() {
-	var mutatedPod, plainPod *v1.Pod
-
-	BeforeEach(func() {
-		mutatedPod = &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{LabelInstasliceMutated: "true"},
-			},
-		}
-		plainPod = &v1.Pod{}
-	})
-
-	labelSelector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			LabelInstasliceMutated: "true",
-		},
-	})
-	predicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return labelSelector.Matches(labels.Set(obj.GetLabels()))
-	})
-
-	It("should return true for created mutated pod", func() {
-		Expect(predicate.Create(event.CreateEvent{Object: mutatedPod})).To(BeTrue())
-	})
-
-	It("should return false for created plain pod", func() {
-		Expect(predicate.Create(event.CreateEvent{Object: plainPod})).To(BeFalse())
-	})
-
-	It("should return true for updated pod if label exists", func() {
-		Expect(predicate.Update(event.UpdateEvent{ObjectOld: plainPod, ObjectNew: mutatedPod})).To(BeTrue())
-	})
-
-	It("should return false for updated pod if no label", func() {
-		plainPod2 := plainPod.DeepCopy()
-		plainPod2.SetName("new-name")
-		Expect(predicate.Update(event.UpdateEvent{ObjectOld: plainPod, ObjectNew: plainPod2})).To(BeFalse())
-	})
-
-	It("should return false for delete plain pod", func() {
-		Expect(predicate.Delete(event.DeleteEvent{Object: plainPod})).To(BeFalse())
-	})
-
-	It("should return true for delete mutated pod", func() {
-		Expect(predicate.Delete(event.DeleteEvent{Object: mutatedPod})).To(BeTrue())
 	})
 })
 

--- a/internal/controller/pod_webhook.go
+++ b/internal/controller/pod_webhook.go
@@ -80,12 +80,6 @@ func (a *PodAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 		},
 	})
 
-	// Add annotation, if pod mutated
-	if pod.Labels == nil {
-		pod.Labels = make(map[string]string)
-	}
-	pod.Labels[LabelInstasliceMutated] = "true"
-
 	// Marshal the updated pod object back to JSON
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {

--- a/internal/controller/pod_webhook_test.go
+++ b/internal/controller/pod_webhook_test.go
@@ -132,7 +132,6 @@ func TestHandle(t *testing.T) {
 				g.Expect(found).To(BeTrue(), fmt.Sprintf("%s limit not found in the modified pod", instasliceQuotaResourceName))
 				expectedMemory := resource.MustParse(tt.expectedLimit)
 				g.Expect(actualMemory.Cmp(expectedMemory)).To(Equal(0), fmt.Sprintf("Expected %s to be %s", instasliceQuotaResourceName, tt.expectedLimit))
-				g.Expect(modifiedPod.Labels).To(HaveKeyWithValue(LabelInstasliceMutated, "true"), "Expected mutated label to be added")
 			} else {
 				g.Expect(resp.Allowed).To(BeTrue(), "Expected request to be allowed without mutation")
 				g.Expect(resp.Patches).To(BeEmpty(), "Expected no patches but found some")

--- a/test/e2e/resources/resource_generator.go
+++ b/test/e2e/resources/resource_generator.go
@@ -52,30 +52,6 @@ func GetVectorAddFinalizerPod() *corev1.Pod {
 	}
 }
 
-func GetNoMutationPod() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "no-mutation-pod",
-			Namespace: "no-mutation-ns",
-		},
-		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyOnFailure,
-			Containers: []corev1.Container{
-				{
-					Name:  "no-mutation-pod",
-					Image: "ubuntu:20.04",
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							"nvidia.com/mig-1g.5gb": resource.MustParse("1"),
-						},
-					},
-					Command: []string{"sh", "-c", "sleep 20"},
-				},
-			},
-		},
-	}
-}
-
 func GetVectorAddNoReqPod() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Reverts openshift/instaslice-operator#522 because this feature doesn't work in OCP. 


```
controller Operator should not mutate pods in an unlabeled namespace
/home/harshal/go/src/github.com/openshift/instaslice-operator/test/e2e/e2e_test.go:283
  [FAILED] in [It] - /home/harshal/go/src/github.com/openshift/instaslice-operator/test/e2e/e2e_test.go:309 @ 05/07/25 10:32:50.958
• [FAILED] [0.404 seconds]
controller Operator [It] should not mutate pods in an unlabeled namespace
/home/harshal/go/src/github.com/openshift/instaslice-operator/test/e2e/e2e_test.go:283

  [FAILED] Failed after 0.042s.
  Webhook should not mutate pod in unlabeled namespace
  Expected
      <string>: true
  not to equal
      <string>: true
  In [It] at: /home/harshal/go/src/github.com/openshift/instaslice-operator/test/e2e/e2e_test.go:309 @ 05/07/25 10:32:50.958
```

@rphillips WDYT? 

xref : https://redhat-internal.slack.com/archives/C07DEU6BD8X/p1746628549300979?thread_ts=1746551007.178079&cid=C07DEU6BD8X 

/hold for e2e to pass
