### PR TITLE
use on-cel-expression to limit which images are triggered by konflux

### DIFF
--- a/.tekton/instaslice-daemonset-pull-request.yaml
+++ b/.tekton/instaslice-daemonset-pull-request.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('cmd/daemonset/|internal/controller/config/|internal/controller/daemonset|Dockerfile.daemonset-ocp|.tekton/instaslice-daemonset-*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-daemonset-push.yaml
+++ b/.tekton/instaslice-daemonset-push.yaml
@@ -6,8 +6,9 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"  && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
+      target_branch == "main"  &&
+      files.all.exists(path, path.matches('cmd/daemonset/|internal/controller/config/|internal/controller/daemonset|Dockerfile.daemonset-ocp|.tekton/instaslice-daemonset-*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-bundle-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-pull-request.yaml
@@ -7,7 +7,9 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('bundle-ocp/|bundle-ocp.Dockerfile|.tekton/instaslice-operator-bundle-*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-bundle-push.yaml
+++ b/.tekton/instaslice-operator-bundle-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
+      target_branch == "main" &&
+      files.all.exists(path, path.matches('bundle-ocp/|bundle-ocp.Dockerfile|.tekton/instaslice-operator-bundle-*'))
+
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-pull-request.yaml
+++ b/.tekton/instaslice-operator-pull-request.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      target_branch == "main" &&
+      files.all.exists(path, !path.matches('bundle-ocp/|bundle-ocp.Dockerfile|.tekton/instaslice-operator-bundle-*|cmd/daemonset/|internal/controller/config/|internal/controller/daemonset|Dockerfile.daemonset-ocp|.tekton/instaslice-daemonset-*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer

--- a/.tekton/instaslice-operator-push.yaml
+++ b/.tekton/instaslice-operator-push.yaml
@@ -6,8 +6,9 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && files.all.exists(path, !path.matches('bundle*|tests/*|.tekton/*bundle*'))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
+      target_branch == "main" &&
+      files.all.exists(path, !path.matches('bundle-ocp/|bundle-ocp.Dockerfile|.tekton/instaslice-operator-bundle-*|cmd/daemonset/|internal/controller/config/|internal/controller/daemonset|Dockerfile.daemonset-ocp|.tekton/instaslice-daemonset-*'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: dynamicacceleratorslicer


### PR DESCRIPTION
This is a further refinement of the on-cel-expression to limit konflux pipelines to only build when necessary.  Bundle was already separated, I have now separated the daemonset as well.  This will reduce build time and eliminate circular nudges.  