### PR TITLE
CR creation only on lable existance

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -20,7 +20,7 @@ import "time"
 
 const (
 	OrgInstaslicePrefix              = "instaslice.redhat.com/"
-	managedLabel                     = OrgInstaslicePrefix + "managed"
+	ManagedLabel                     = OrgInstaslicePrefix + "managed"
 	GateName                         = OrgInstaslicePrefix + "accelerator"
 	FinalizerName                    = GateName
 	QuotaResourceName                = OrgInstaslicePrefix + "accelerator-memory-quota"
@@ -43,5 +43,6 @@ const (
 
 	Requeue1sDelay  = 1 * time.Second
 	Requeue2sDelay  = 2 * time.Second
-	requeue10sDelay = 10 * time.Second
+	Requeue5sDelay  = 5 * time.Second
+	Requeue10sDelay = 10 * time.Second
 )

--- a/internal/controller/daemonset/instaslice_daemonset.go
+++ b/internal/controller/daemonset/instaslice_daemonset.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -126,8 +127,26 @@ func (r *InstaSliceDaemonsetReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	var instaslice inferencev1alpha1.Instaslice
 	if err := r.Get(ctx, nsName, &instaslice); err != nil {
+		if apierrors.IsNotFound(err) {
+			var node v1.Node
+			if err := r.Get(ctx, client.ObjectKey{Name: r.NodeName}, &node); err != nil {
+				log.Error(err, "error fetching node for missing Instaslice")
+				return ctrl.Result{RequeueAfter: controller.Requeue1sDelay}, nil
+			}
+			if _, ok := node.Labels[controller.ManagedLabel]; !ok {
+				log.Info("Node is not labeled managed, skipping Instaslice discovery", "node", r.NodeName)
+				return ctrl.Result{RequeueAfter: controller.Requeue2sDelay}, nil
+			}
+			log.Info("Instaslice CR missing for managed node, invoking discovery", "node", r.NodeName)
+			if err := r.discoverMigEnabledGpuWithSlices(); err != nil {
+				log.Error(err, "failed to repopulate Instaslice CR after recreation")
+				return ctrl.Result{Requeue: true}, err
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+
 		log.Error(err, "Error getting Instaslice", "name", r.NodeName)
-		return ctrl.Result{RequeueAfter: controller.Requeue1sDelay}, err
+		return ctrl.Result{RequeueAfter: controller.Requeue5sDelay}, err
 	}
 	// get the node object to watch out for any related events
 	var node v1.Node
@@ -406,9 +425,9 @@ func (r *InstaSliceDaemonsetReconciler) cleanUpCiAndGi(ctx context.Context, allo
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	var err error
 	restConfig := mgr.GetConfig()
 
-	var err error
 	r.kubeClient, err = kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return err
@@ -417,9 +436,9 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 		return err
 	}
 
+	// Init InstaSlice CR if node is labeled, after manager is elected
 	// Init InstaSlice obj as the first thing when cache is loaded.
 	// RunnableFunc is added to the manager.
-	// This function waits for the manager to be elected (<-mgr.Elected()) and then runs InstaSlice init code.
 	mgrAddErr := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		log := logr.FromContext(ctx)
 		<-mgr.Elected() // Wait for the manager to be elected
@@ -428,11 +447,28 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 			Name:      r.NodeName,
 			Namespace: controller.InstaSliceOperatorNamespace,
 		}
-		err := r.Get(ctx, typeNamespacedName, &instaslice)
+		err := r.Get(ctx, types.NamespacedName{Name: r.NodeName, Namespace: controller.InstaSliceOperatorNamespace}, &instaslice)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("Instaslice CR not found on startup, skipping patch until created by Reconcile()")
+				return nil
+			}
 			log.Error(err, "Unable to fetch Instaslice for node", "nodeName", r.NodeName)
+			return err
 		}
 
+		var node v1.Node
+		if err := r.Get(ctx, client.ObjectKey{Name: r.NodeName}, &node); err != nil {
+			log.Error(err, "error fetching node before discovery")
+			return err
+		}
+
+		if _, ok := node.Labels[controller.ManagedLabel]; !ok {
+			log.Info("Node is not labeled managed, skipping discovery and patching", "node", r.NodeName)
+			return nil
+		}
+
+		log.Info("Node is managed, running discovery on init", "node", r.NodeName)
 		if r.Config.EmulatorModeEnable {
 			fakeCapacity := utils.GenerateFakeCapacity(r.NodeName)
 			err := r.Create(ctx, fakeCapacity)
@@ -482,12 +518,11 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 			}
 		} else {
 			if instaslice.Status.NodeResources.NodeGPUs == nil { // TODO - use those conditions!
-				if _, e := r.discoverMigEnabledGpuWithSlices(); e != nil {
+				if e := r.discoverMigEnabledGpuWithSlices(); e != nil {
 					log.Error(e, "Error discovering MIG GPUs on node init")
 				}
 			}
 		}
-
 		if err := r.Get(ctx, typeNamespacedName, &instaslice); err != nil {
 			log.Error(err, "Unable to fetch Instaslice after discovery", "nodeName", r.NodeName)
 			return err
@@ -509,7 +544,6 @@ func (r *InstaSliceDaemonsetReconciler) SetupWithManager(mgr ctrl.Manager) error
 				return err
 			}
 		}
-
 		return nil
 	}))
 	if mgrAddErr != nil {
@@ -539,7 +573,7 @@ func CalculateTotalMemoryGB(nodeGPUs []inferencev1alpha1.DiscoveredGPU) (float64
 }
 
 // This function discovers MIG devices as the plugin comes up. this is run exactly once.
-func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() ([]string, error) {
+func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() error {
 	log := logr.FromContext(context.TODO())
 
 	instaslice := &inferencev1alpha1.Instaslice{}
@@ -549,16 +583,16 @@ func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() ([]str
 	customCtx := context.TODO()
 	errToCreate := r.Create(customCtx, instaslice)
 	if errToCreate != nil {
-		return nil, errToCreate
+		return errToCreate
 	}
 	instaslice, _, _, err := r.discoverAvailableProfilesOnGpus(instaslice)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	totalMemoryGB, err := CalculateTotalMemoryGB(instaslice.Status.NodeResources.NodeGPUs)
 	if err != nil {
 		log.Error(err, "unable to get GPU memory")
-		return nil, err
+		return err
 	}
 	nodeResourceList, err := r.classicalResourcesAndGPUMemOnNode(context.TODO(), r.NodeName, strconv.FormatFloat(totalMemoryGB, 'f', 2, 64))
 	if err != nil {
@@ -570,15 +604,15 @@ func (r *InstaSliceDaemonsetReconciler) discoverMigEnabledGpuWithSlices() ([]str
 
 	log.Info("classical resources obtained are ", "cpu", nodeResourceList.Cpu().String(), "memory", nodeResourceList.Memory().String())
 	if err = r.Status().Update(customCtx, instaslice); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Patch the node capacity to reflect the total GPU memory
 	if err := r.patchNodeStatusForNode(customCtx, r.NodeName, int(totalMemoryGB)); err != nil {
-		return nil, err
+		return err
 	}
 
-	return discoveredGpusOnHost, nil
+	return nil
 }
 
 func (r *InstaSliceDaemonsetReconciler) addMigCapacityToNode(ctx context.Context, instaslice *inferencev1alpha1.Instaslice) error {

--- a/internal/controller/instaslice_controller.go
+++ b/internal/controller/instaslice_controller.go
@@ -127,11 +127,12 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
-	managed := node.Labels[managedLabel] == InstasliceManagedTrue
+	instasliceKey := types.NamespacedName{Namespace: InstaSliceOperatorNamespace, Name: node.Name}
+	managed := node.Labels[ManagedLabel] == InstasliceManagedTrue
+
 	if !managed {
 		logger.Info("Node not managed by InstaSlice, cleaning up")
 		instaslice := &inferencev1alpha1.Instaslice{}
-		instasliceKey := types.NamespacedName{Namespace: InstaSliceOperatorNamespace, Name: node.Name}
 		if err := r.Get(ctx, instasliceKey, instaslice); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
@@ -143,8 +144,19 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			return ctrl.Result{}, fmt.Errorf("failed to clean up resources for unmanaged node %s: %w", node.Name, err)
 		}
 		logger.Info("Cleaned up instaslice extended resources for unmanaged node")
+		return ctrl.Result{}, nil
 	}
 
+	// Do not create Instaslice CR here; rely on DaemonSet to handle CR creation.
+	logger.Info("Node is managed by instaslice, waiting for DaemonSet to reconcile CR if necessary")
+	instaslice := &inferencev1alpha1.Instaslice{}
+	if err := r.Get(ctx, instasliceKey, instaslice); err == nil {
+		logger.Info("Instaslice CR was created for managed node", "name", instaslice.Name)
+	} else if errors.IsNotFound(err) {
+		logger.Info("Instaslice CR does not yet exist for managed node, waiting for DaemonSet to create")
+	} else {
+		return ctrl.Result{}, fmt.Errorf("error checking for Instaslice CR existence: %w", err)
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -225,12 +237,18 @@ func (r *InstasliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		node := &v1.Node{}
 		if err = r.Get(ctx, client.ObjectKey{Name: instaslice.Name}, node); err != nil {
 			log.Error(err, "error getting the node object", "name", instaslice.Name)
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, err
+			return ctrl.Result{RequeueAfter: Requeue1sDelay}, err
 		}
+
+		if instaslice.Status.NodeResources.BootID == "" {
+			log.Info("Instaslice boot ID not yet populated, requeuing", "node", node.Name)
+			return ctrl.Result{RequeueAfter: Requeue5sDelay}, nil
+		}
+
 		if instaslice.Status.NodeResources.BootID != node.Status.NodeInfo.BootID {
 			err := fmt.Errorf("instaslice not in sync with the node as the boot id doesn't match")
 			log.Error(err, "instaslice's boot id not matching node's boot id", "node's boot id", node.Status.NodeInfo.BootID, "instaslice's boot id", instaslice.Status.NodeResources.BootID)
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, err
+			return ctrl.Result{RequeueAfter: Requeue10sDelay}, err
 		}
 	}
 
@@ -609,6 +627,7 @@ func (r *InstasliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return true, nil
 			}
 			log.Info("No Instaslice objects found, waiting...")
+			log.Info("If this node is expected to be managed, ensure the label '" + ManagedLabel + "' is set to '" + InstasliceManagedTrue + "'")
 			return false, nil
 		})
 		if retryErr != nil {
@@ -657,8 +676,8 @@ func (r *InstasliceReconciler) setupWithManager(mgr ctrl.Manager) error {
 			oldNode := e.ObjectOld.(*v1.Node)
 			newNode := e.ObjectNew.(*v1.Node)
 			// Trigger reconcile when instaslice managed label is added or removed
-			oldManaged := oldNode.Labels[managedLabel]
-			newManaged := newNode.Labels[managedLabel]
+			oldManaged := oldNode.Labels[ManagedLabel]
+			newManaged := newNode.Labels[ManagedLabel]
 			return oldManaged != newManaged
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
@@ -1030,6 +1049,7 @@ func (r *InstasliceReconciler) ReconcileSCC(ctx context.Context) error {
 }
 
 func (r *InstasliceReconciler) labelManagedNodes(ctx context.Context) error {
+	log := logr.FromContext(ctx)
 	var nodeList v1.NodeList
 	if err := r.List(ctx, &nodeList); err != nil {
 		return err
@@ -1040,15 +1060,16 @@ func (r *InstasliceReconciler) labelManagedNodes(ctx context.Context) error {
 			continue
 		}
 		// Add label if missing
-		if node.Labels[managedLabel] != InstasliceManagedTrue {
+		if node.Labels[ManagedLabel] != InstasliceManagedTrue {
 			patch := client.MergeFrom(node.DeepCopy())
 			if node.Labels == nil {
 				node.Labels = map[string]string{}
 			}
-			node.Labels[managedLabel] = InstasliceManagedTrue
+			node.Labels[ManagedLabel] = InstasliceManagedTrue
 			if err := r.Patch(ctx, &node, patch); err != nil {
 				return fmt.Errorf("failed to patch node %s with managed label: %w", node.Name, err)
 			}
+			log.Info("Node automatically labeled with: ", "nodeName", node.Name, "ManagedLabel", ManagedLabel)
 		}
 	}
 	return nil


### PR DESCRIPTION
- Daemonset exclusively handles CR creation after managed label - `instaslice.redhat.com/managed` check
- Initial CR creation in setupwithmanager by daemonset if managed label exists for node
- CR recreation by daemonset after label removed and readded in the daemonset reconciler

**Updated**: Successful run of:
- [x] make test
- [x] make lint
- [x] make test-e2e-kind-emulated
- [x] make test-e2e on kind cluster with GPUs
- [ ] make test-e2e on ocp cluster with GPUs [@sairameshv to test]