### PR TITLE
Update Makefile contents

### DIFF
--- a/hack/deploy-nvidia.sh
+++ b/hack/deploy-nvidia.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 set -x
 
-KUBECTL=${KUBECTL:-kubectl}
+KUBECTL=${KUBECTL:-oc}
 TIMEOUT=${TIMEOUT:-600}
 NODE_TIMEOUT=${NODE_TIMEOUT:-900}
 


### PR DESCRIPTION
Update Makefile to install the following operators that helps in automating CI jobs before executing the e2e tests
- cert-manager-operator
- nfd-operator
- nvidia-gpu-operator