### PR TITLE
Use internal RH registry and create scaffolding to preserve the developer registry images

### DIFF
--- a/.tekton/instaslice-daemonset-next-push.yaml
+++ b/.tekton/instaslice-daemonset-next-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.openshift.io/build-nudge-files: |
-      related_images.json
+      related_images.json, related_images.developer.json
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch

--- a/.tekton/instaslice-operator-next-push.yaml
+++ b/.tekton/instaslice-operator-next-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     build.appstudio.openshift.io/build-nudge-files: |
-      related_images.json
+      related_images.json, related_images.developer.json
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch

--- a/.tekton/instaslice-scheduler-next-push.yaml
+++ b/.tekton/instaslice-scheduler-next-push.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: |
+      related_images.json, related_images.developer.json
     build.appstudio.openshift.io/repo: https://github.com/openshift/instaslice-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/instaslice-webhook-next-push.yaml
+++ b/.tekton/instaslice-webhook-next-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: |
-      related_images.json
+      related_images.json, related_images.developer.json
     build.appstudio.openshift.io/repo: https://github.com/openshift/instaslice-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/bundle.developer.Dockerfile
+++ b/bundle.developer.Dockerfile
@@ -1,0 +1,49 @@
+FROM registry.redhat.io/ubi9/ubi:9.6 as builder
+RUN dnf -y install jq
+
+ARG RELATED_IMAGE_FILE=related_images.public.json
+ARG CSV_FILE=bundle-ocp/manifests/das-operator.clusterserviceversion.yaml
+ARG OPERATOR_IMAGE_ORIGINAL=quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next:latest
+ARG WEBHOOK_IMAGE_ORIGINAL=quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next:latest
+ARG SCHEDULER_IMAGE_ORIGINAL=quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-scheduler-next:latest
+ARG DAEMONSET_IMAGE_ORIGINAL=quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset-next:latest
+
+COPY ${CSV_FILE} /manifests/das-operator.clusterserviceversion.yaml
+COPY ${RELATED_IMAGE_FILE} /${RELATED_IMAGE_FILE}
+
+RUN OPERATOR_IMAGE=$(jq -r '.[] | select(.name == "instaslice-operator-next") | .image' /${RELATED_IMAGE_FILE}) && sed -i "s|${OPERATOR_IMAGE_ORIGINAL}|${OPERATOR_IMAGE}|g" /manifests/das-operator.clusterserviceversion.yaml
+RUN WEBHOOK_IMAGE=$(jq -r '.[] | select(.name == "instaslice-webhook-next") | .image' /${RELATED_IMAGE_FILE}) && sed -i "s|${WEBHOOK_IMAGE_ORIGINAL}|${WEBHOOK_IMAGE}|g" /manifests/das-operator.clusterserviceversion.yaml
+RUN SCHEDULER_IMAGE=$(jq -r '.[] | select(.name == "instaslice-scheduler-next") | .image' /${RELATED_IMAGE_FILE}) && sed -i "s|${SCHEDULER_IMAGE_ORIGINAL}|${SCHEDULER_IMAGE}|g" /manifests/das-operator.clusterserviceversion.yaml
+RUN DAEMONSET_IMAGE=$(jq -r '.[] | select(.name == "instaslice-daemonset-next") | .image' /${RELATED_IMAGE_FILE}) && sed -i "s|${DAEMONSET_IMAGE_ORIGINAL}|${DAEMONSET_IMAGE}|g" /manifests/das-operator.clusterserviceversion.yaml
+
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=das-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
+
+# Copy files to locations specified by labels.
+
+COPY bundle-ocp/manifests /manifests
+COPY bundle-ocp/metadata /metadata
+COPY --from=builder manifests/das-operator.clusterserviceversion.yaml /manifests/${CSV_FILE}
+
+ARG NAME=das-operator-bundle
+ARG DESCRIPTION="The das operator bundle."
+
+LABEL com.redhat.component=$NAME
+LABEL description=$DESCRIPTION
+LABEL io.k8s.description=$DESCRIPTION
+LABEL io.k8s.display-name=$NAME
+LABEL name=$NAME
+LABEL summary=$DESCRIPTION
+LABEL distribution-scope=public
+LABEL release="1"
+LABEL url="https://access.redhat.com/"
+LABEL version="1"

--- a/related_images.developer.json
+++ b/related_images.developer.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "instaslice-scheduler-next",
+    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-scheduler-next@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e"
+  },
+  {
+    "name": "instaslice-daemonset-next",
+    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset-next@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc"
+  },
+  {
+    "name": "instaslice-webhook-next",
+    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41"
+  },
+  {
+    "name": "instaslice-operator-next",
+    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768"
+  },
+  {
+    "name": "instaslice-operator-bundle-public-next",
+    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-bundle-public-next@sha256:e12719d39b39c245b673805e50040e8ec413e88c1d63867ea78ffb7135253f35"
+  }
+]

--- a/related_images.json
+++ b/related_images.json
@@ -1,22 +1,22 @@
 [
   {
     "name": "instaslice-scheduler-next",
-    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-scheduler-next@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e"
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-next@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e"
   },
   {
     "name": "instaslice-daemonset-next",
-    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset-next@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc"
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-next@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc"
   },
   {
     "name": "instaslice-webhook-next",
-    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41"
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-next@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41"
   },
   {
     "name": "instaslice-operator-next",
-    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768"
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768"
   },
   {
     "name": "instaslice-operator-bundle-next",
-    "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-bundle-next@sha256:e12719d39b39c245b673805e50040e8ec413e88c1d63867ea78ffb7135253f35"
+    "image": "registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-bundle-next@sha256:e12719d39b39c245b673805e50040e8ec413e88c1d63867ea78ffb7135253f35"
   }
 ]


### PR DESCRIPTION
* Adds a related_images.developer.json file which preserves the references to the developer  quay images
* Changes related_images.json to use the redhat.registry.io images references
* Should be able to create one more Konflux pipeline to push a 'developer' bundle image for installation. This developer bundle preserves what we have today for deployments and does not require mirrorsets for install. 