### PR TITLE
add justfile and start removing logic from makefile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,91 @@
+export PODMAN := env('PODMAN', 'podman')
+export KUBECTL := env('KUBECTL', 'oc')
+export EMULATED_MODE := env('EMULATED_MODE', 'disabled')
+export RELATED_IMAGES := env('RELATED_IMAGES', 'related_images.json')
+export DEPLOY_DIR := env('DEPLOY_DIR', 'deploy')
+
+
+export OPERATOR_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-next") | .image' $1""", RELATED_IMAGES)
+export WEBHOOK_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-webhook-next") | .image' $1""", RELATED_IMAGES)
+export SCHEDULER_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-scheduler-next") | .image' $1""", RELATED_IMAGES)
+export DAEMONSET_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-daemonset-next") | .image' $1""", RELATED_IMAGES)
+
+export OPERATOR_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next:latest"
+export WEBHOOK_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next:latest"
+export SCHEDULER_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-scheduler-next:latest"
+export DAEMONSET_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset-next:latest"
+
+default:
+  @just --list
+  @just info
+
+info:
+  @echo
+  @echo "Related Images: ${RELATED_IMAGES}"
+  @echo
+  @echo "    Operator Image: {{OPERATOR_IMAGE}}"
+  @echo "     Webhook Image: {{WEBHOOK_IMAGE}}"
+  @echo "   Scheduler Image: {{SCHEDULER_IMAGE}}"
+  @echo "   Daemonset Image: {{DAEMONSET_IMAGE}}"
+  @echo "     Emulated Mode: {{EMULATED_MODE}}"
+  @echo
+
+# Deploy DAS on OpenShift Container Platform
+deploy-das-ocp: info regen-crd-k8s
+  #!/usr/bin/env bash
+  
+  set -eou pipefail
+
+  TMP_DIR=$(mktemp -d)
+  cp ${DEPLOY_DIR}/*.yaml ${TMP_DIR}/
+
+  sed -i "s/emulatedMode: .*/emulatedMode: \"${EMULATED_MODE}\"/" ${TMP_DIR}/03_instaslice_operator.cr.yaml
+
+  echo "Rewriting Operator Image"
+  sed -i "s|${OPERATOR_IMAGE_ORIGINAL}|${OPERATOR_IMAGE}|g" ${TMP_DIR}/04_deployment.yaml
+  echo "Rewriting Webhook Image"
+  sed -i "s|${WEBHOOK_IMAGE_ORIGINAL}|${WEBHOOK_IMAGE}|g" ${TMP_DIR}/04_deployment.yaml
+  echo "Rewriting Scheduler Image"
+  sed -i "s|${SCHEDULER_IMAGE_ORIGINAL}|${SCHEDULER_IMAGE}|g" ${TMP_DIR}/04_deployment.yaml
+  echo "Rewriting Daemonset Image"
+  sed -i "s|${DAEMONSET_IMAGE_ORIGINAL}|${DAEMONSET_IMAGE}|g" ${TMP_DIR}/04_deployment.yaml
+  echo "Rewriting Emulated Mode"
+  sed -i "s/emulatedMode: .*/emulatedMode: \"${EMULATED_MODE}\"/" ${TMP_DIR}/03_instaslice_operator.cr.yaml
+
+  ${KUBECTL} apply -f ${TMP_DIR}/
+
+regen-crd-k8s:
+  @echo "Generating CRDs into deploy directory"
+  go build -o _output/tools/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
+  rm -f {{DEPLOY_DIR}}/00_instaslice-operator.crd.yaml
+  rm -f {{DEPLOY_DIR}}/00_nodeaccelerators.crd.yaml
+  ./_output/tools/bin/controller-gen crd paths=./pkg/apis/dasoperator/v1alpha1/... schemapatch:manifests=./manifests output:crd:dir=./{{DEPLOY_DIR}}
+  mv {{DEPLOY_DIR}}/inference.redhat.com_dasoperators.yaml {{DEPLOY_DIR}}/00_instaslice-operator.crd.yaml
+  mv {{DEPLOY_DIR}}/inference.redhat.com_nodeaccelerators.yaml {{DEPLOY_DIR}}/00_nodeaccelerators.crd.yaml
+
+build-push-parallel:
+  #!/usr/bin/env -S parallel --shebang --ungroup --jobs {{ num_cpus() }}
+  just build-push-scheduler
+  just build-push-daemonset
+  just build-push-operator
+  just build-push-webhook
+
+# Build and push scheduler image
+build-push-scheduler:
+  ${PODMAN} build -f Dockerfile.scheduler.ocp -t {{SCHEDULER_IMAGE}} .
+  ${PODMAN} push {{SCHEDULER_IMAGE}}
+
+# Build and push daemonset image
+build-push-daemonset:
+  ${PODMAN} build -f Dockerfile.daemonset.ocp -t {{DAEMONSET_IMAGE}} .
+  ${PODMAN} push {{DAEMONSET_IMAGE}}
+
+# Build and push operator image
+build-push-operator:
+  ${PODMAN} build -f Dockerfile.ocp -t {{OPERATOR_IMAGE}} .
+  ${PODMAN} push {{OPERATOR_IMAGE}}
+
+# Build and push webhook image
+build-push-webhook:
+  ${PODMAN} build -f Dockerfile.webhook.ocp -t {{WEBHOOK_IMAGE}} .
+  ${PODMAN} push {{WEBHOOK_IMAGE}}

--- a/README.md
+++ b/README.md
@@ -3,19 +3,29 @@
 Dynamic Accelerator Slicer (DAS) is an operator that dynamically partitions GPU accelerators in Kubernetes and OpenShift. It currently ships with a reference implementation for NVIDIA Multi-Instance GPU (MIG) and is designed to support additional technologies such as NVIDIA MPS or GPUs from other vendors.
 
 ## Table of Contents
-- [Features](#features)
-- [Getting Started](#getting-started)
-  - [Emulated Mode](#emulated-mode)
-  - [Running on OpenShift](#running-on-openshift)
-  - [Operator Bundle Development](#operator-bundle-development)
-- [Architecture](#architecture)
-  - [MIG scheduler plugin](#mig-scheduler-plugin)
-  - [AllocationClaim resource](#allocationclaim-resource)
-- [Debugging](#debugging)
-- [Running E2E tests](#running-e2e-tests)
-- [Uninstalling](#uninstalling)
-- [Contributing](#contributing)
-- [License](#license)
+- [Dynamic Accelerator Slicer (DAS) Operator](#dynamic-accelerator-slicer-das-operator)
+  - [Table of Contents](#table-of-contents)
+  - [Features](#features)
+  - [Getting Started](#getting-started)
+    - [Kubernetes](#kubernetes)
+    - [Running on OpenShift](#running-on-openshift)
+    - [Operator Bundle Development](#operator-bundle-development)
+  - [Justfile Usage](#justfile-usage)
+    - [Prerequisites](#prerequisites)
+    - [Available Commands](#available-commands)
+    - [Building and Pushing Images](#building-and-pushing-images)
+    - [Deployment](#deployment)
+    - [Use custom developer images](#use-custom-developer-images)
+    - [Configuration](#configuration)
+  - [Architecture](#architecture)
+    - [MIG scheduler plugin](#mig-scheduler-plugin)
+    - [AllocationClaim resource](#allocationclaim-resource)
+  - [Emulated mode](#emulated-mode)
+  - [Debugging](#debugging)
+  - [Running E2E tests](#running-e2e-tests)
+  - [Uninstalling](#uninstalling)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Features
 
@@ -159,6 +169,98 @@ The operator-sdk doc does not go over base csv criteria, the details can be foun
 inspecting the bundle generation code here:
 https://github.com/operator-framework/operator-sdk/blob/0eefc52889ff3dfe4af406038709e6c5ba7398e5/internal/generate/clusterserviceversion/clusterserviceversion.go#L148-L159
 
+=======
+## Justfile Usage
+
+This project includes a [Justfile](https://github.com/casey/just) for convenient task automation. The Justfile provides several commands for building, pushing, and deploying the operator components.
+
+### Prerequisites
+
+Install [just](https://github.com/casey/just) command runner:
+
+```bash
+# On macOS
+brew install just
+
+# On Fedora/RHEL
+dnf install just
+
+# On Ubuntu/Debian
+apt install just
+
+# Or via cargo
+cargo install just
+```
+
+### Available Commands
+
+List all available commands:
+```bash
+just
+```
+
+View current configuration:
+```bash
+just info
+```
+
+### Building and Pushing Images
+
+Build and push individual component images:
+```bash
+just build-push-scheduler   # Build and push scheduler image
+just build-push-daemonset   # Build and push daemonset image
+just build-push-operator    # Build and push operator image
+just build-push-webhook     # Build and push webhook image
+```
+
+Build and push all images in parallel:
+```bash
+just build-push-parallel
+```
+
+### Deployment
+
+Deploy DAS on OpenShift Container Platform:
+```bash
+just deploy-das-ocp
+```
+
+Generate CRDs:
+```bash
+just regen-crd-k8s
+```
+
+### Use custom developer images
+
+Modify the related_images.developer.json file to contain the target developer image repositories to use.
+
+```sh
+quay.io/username/image:latest
+```
+
+Then set the RELATED_IMAGES environment variable to related_images.developer.json.
+
+```sh
+RELATED_IMAGES=related_images.developer.json just
+```
+
+### Configuration
+
+The Justfile uses environment variables for configuration. You can customize these by setting them in your environment or creating a `.env` file:
+
+- `PODMAN` - Container runtime (default: `podman`)
+- `KUBECTL` - Kubernetes CLI (default: `oc`)
+- `EMULATED_MODE` - Enable emulated mode (default: `disabled`)
+- `RELATED_IMAGES` - Path to related images JSON file (default: `related_images.json`)
+- `DEPLOY_DIR` - Deployment directory (default: `deploy`)
+
+Example:
+```bash
+export EMULATED_MODE=enabled
+just deploy-das-ocp
+
+```
 
 ## Architecture
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,18 +13,25 @@
   "recreateWhen": "always",
   "tekton": {
     "enabled": true,
-    "packageRules": [
-      {
-        "matchUpdateTypes": [
-          "minor",
-          "patch",
-          "pin",
-          "digest"
-        ],
-        "automerge": true,
-	"addLabels": ["lgtm", "approved"]
-      }
-    ]
+    "addLabels": [
+      "approved",
+      "lgtm"
+    ],
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "rebase",
+    "commitMessagePrefix": "NO-JIRA:",
+    "fileMatch": [
+      "related_images.json$",
+      "related_images.developer.json$",
+      "\\.yaml$",
+      "\\.yml$"
+    ],
+    "includePaths": [
+      ".tekton/**",
+      "."
+    ],
+    "platformAutomerge": true
   },
   "dockerfile": {
     "enabled": true,
@@ -35,7 +42,10 @@
           "*.Dockerfile"
         ],
         "automerge": true,
-	"addLabels": ["lgtm", "approved"]
+        "addLabels": [
+          "lgtm",
+          "approved"
+        ]
       }
     ]
   },

--- a/renovate.json
+++ b/renovate.json
@@ -37,14 +37,17 @@
     "enabled": true,
     "packageRules": [
       {
-        "matchFileNames": [
-          "Dockerfile.*",
-          "*.Dockerfile"
-        ],
-        "automerge": true,
         "addLabels": [
           "lgtm",
           "approved"
+        ],
+        "automerge": true,
+        "automergeType": "pr",
+        "automergeStrategy": "rebase",
+        "commitMessagePrefix": "NO-JIRA:",
+        "matchFileNames": [
+          "Dockerfile.*",
+          "*.Dockerfile"
         ]
       }
     ]


### PR DESCRIPTION
Just is a command runner. Running bash-style scripts from a Makefile is error prone, and not very extensible. We can do most of the scripting in just and leave the makefile for the usual building of things.

```
# just
Available recipes:
    build-push-daemonset    # Build and push daemonset image
    build-push-operator     # Build and push operator image
    build-push-parallel
    build-push-scheduler    # Build and push scheduler image
    build-push-webhook      # Build and push webhook image
    default
    info
    oc-deploy-das-ocp       # Deploy DAS on OpenShift Container Platform
    rewrite-deployment-yaml

Related Images: related_images.json

    Operator Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768
     Webhook Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-next@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41
   Scheduler Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-next@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e
   Daemonset Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-next@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc
     Emulated Mode: false
```

```
✦ ❯ RELATED_IMAGES=related_images.developer.json just
Available recipes:
    build-push-daemonset    # Build and push daemonset image
    build-push-operator     # Build and push operator image
    build-push-parallel
    build-push-scheduler    # Build and push scheduler image
    build-push-webhook      # Build and push webhook image
    default
    info
    oc-deploy-das-ocp       # Deploy DAS on OpenShift Container Platform
    rewrite-deployment-yaml

Related Images: related_images.developer.json

    Operator Image: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768
     Webhook Image: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next@sha256:06d33ee47fe195492adcb0eba11dfdc5147d021f83118ffbb8130c1914ffa630
   Scheduler Image: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-scheduler-next@sha256:2770eef6c0c3e8f7d9a204f535cb4cee09e3ae1b04432261fd1606f039e791bb
   Daemonset Image: quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset-next@sha256:1c5273912cecfd4b220e53e08c3d78724e5fa1c8aaf18606833b27c8810b8fe8
     Emulated Mode: false
```

```
EMULATED_MODE=true just info
Related Images: related_images.json

    Operator Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768
     Webhook Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-next@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41
   Scheduler Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-next@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e
   Daemonset Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-next@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc
     Emulated Mode: true
```