### PR TITLE
cleanup justfile and add more functionality

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false,
+    "headings": false
+  }
+}

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,7 @@ export DEPLOY_DIR := env('DEPLOY_DIR', 'deploy')
 export OPERATOR_SDK := env('OPERATOR_SDK', 'operator-sdk')
 export OPERATOR_VERSION := env('OPERATOR_VERSION', '0.1.0')
 export GOLANGCI_LINT:= env('GOLANGCI_LINT', 'golangci-lint')
+export MARKDOWNLINT := env('MARKDOWNLINT', 'markdownlint')
 
 export OPERATOR_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-next") | .image' $1""", RELATED_IMAGES)
 export WEBHOOK_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-webhook-next") | .image' $1""", RELATED_IMAGES)
@@ -171,9 +172,23 @@ deploy-nfd-ocp:
   hack/deploy-nfd.sh
 
 # Run golangci-lint on the codebase
-lint:
+lint-go:
   {{GOLANGCI_LINT}} run --timeout 5m ./pkg/...
 
 # Run golangci-lint and automatically fix issues
-lint-fix: lint
+lint-go-fix: lint-go
   {{GOLANGCI_LINT}} run --fix
+
+# Run all linting (markdown and Go)
+lint: lint-md lint-go
+
+# Run markdownlint on markdown files
+lint-md:
+  {{MARKDOWNLINT}} -c .markdownlint.json *.md
+
+# Run markdownlint and automatically fix issues
+lint-md-fix:
+  {{MARKDOWNLINT}} -c .markdownlint.json --fix *.md
+
+# Run all linting fixes (markdown and Go)
+lint-fix: lint-md-fix lint-go-fix

--- a/Justfile
+++ b/Justfile
@@ -3,22 +3,27 @@ export KUBECTL := env('KUBECTL', 'oc')
 export EMULATED_MODE := env('EMULATED_MODE', 'disabled')
 export RELATED_IMAGES := env('RELATED_IMAGES', 'related_images.json')
 export DEPLOY_DIR := env('DEPLOY_DIR', 'deploy')
-
+export OPERATOR_SDK := env('OPERATOR_SDK', 'operator-sdk')
+export OPERATOR_VERSION := env('OPERATOR_VERSION', '0.1.0')
+export GOLANGCI_LINT:= env('GOLANGCI_LINT', 'golangci-lint')
 
 export OPERATOR_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-next") | .image' $1""", RELATED_IMAGES)
 export WEBHOOK_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-webhook-next") | .image' $1""", RELATED_IMAGES)
 export SCHEDULER_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-scheduler-next") | .image' $1""", RELATED_IMAGES)
 export DAEMONSET_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-daemonset-next") | .image' $1""", RELATED_IMAGES)
+export BUNDLE_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-bundle-next") | .image' $1""", RELATED_IMAGES)
 
 export OPERATOR_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next:latest"
 export WEBHOOK_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next:latest"
 export SCHEDULER_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-scheduler-next:latest"
 export DAEMONSET_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-daemonset-next:latest"
 
+# Default target - shows available commands and environment info
 default:
   @just --list
   @just info
 
+# Display environment and image configuration information
 info:
   @echo
   @echo "Related Images: ${RELATED_IMAGES}"
@@ -52,8 +57,9 @@ deploy-das-ocp: info regen-crd-k8s
   echo "Rewriting Emulated Mode"
   sed -i "s/emulatedMode: .*/emulatedMode: \"${EMULATED_MODE}\"/" ${TMP_DIR}/03_instaslice_operator.cr.yaml
 
-  ${KUBECTL} apply -f ${TMP_DIR}/
+  {{KUBECTL}} apply -f ${TMP_DIR}/
 
+# Regenerate Custom Resource Definitions (CRDs) for Kubernetes
 regen-crd-k8s:
   @echo "Generating CRDs into deploy directory"
   go build -o _output/tools/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
@@ -63,6 +69,7 @@ regen-crd-k8s:
   mv {{DEPLOY_DIR}}/inference.redhat.com_dasoperators.yaml {{DEPLOY_DIR}}/00_instaslice-operator.crd.yaml
   mv {{DEPLOY_DIR}}/inference.redhat.com_nodeaccelerators.yaml {{DEPLOY_DIR}}/00_nodeaccelerators.crd.yaml
 
+# Build and push all container images in parallel
 build-push-parallel:
   #!/usr/bin/env -S parallel --shebang --ungroup --jobs {{ num_cpus() }}
   just build-push-scheduler
@@ -72,20 +79,101 @@ build-push-parallel:
 
 # Build and push scheduler image
 build-push-scheduler:
-  ${PODMAN} build -f Dockerfile.scheduler.ocp -t {{SCHEDULER_IMAGE}} .
-  ${PODMAN} push {{SCHEDULER_IMAGE}}
+  {{PODMAN}} build -f Dockerfile.scheduler.ocp -t {{SCHEDULER_IMAGE}} .
+  {{PODMAN}} push {{SCHEDULER_IMAGE}}
 
 # Build and push daemonset image
 build-push-daemonset:
-  ${PODMAN} build -f Dockerfile.daemonset.ocp -t {{DAEMONSET_IMAGE}} .
-  ${PODMAN} push {{DAEMONSET_IMAGE}}
+  {{PODMAN}} build -f Dockerfile.daemonset.ocp -t {{DAEMONSET_IMAGE}} .
+  {{PODMAN}} push {{DAEMONSET_IMAGE}}
 
 # Build and push operator image
 build-push-operator:
-  ${PODMAN} build -f Dockerfile.ocp -t {{OPERATOR_IMAGE}} .
-  ${PODMAN} push {{OPERATOR_IMAGE}}
+  {{PODMAN}} build -f Dockerfile.ocp -t {{OPERATOR_IMAGE}} .
+  {{PODMAN}} push {{OPERATOR_IMAGE}}
 
 # Build and push webhook image
 build-push-webhook:
-  ${PODMAN} build -f Dockerfile.webhook.ocp -t {{WEBHOOK_IMAGE}} .
-  ${PODMAN} push {{WEBHOOK_IMAGE}}
+  {{PODMAN}} build -f Dockerfile.webhook.ocp -t {{WEBHOOK_IMAGE}} .
+  {{PODMAN}} push {{WEBHOOK_IMAGE}}
+
+# Generate operator bundle using operator-sdk
+bundle-generate:
+	{{OPERATOR_SDK}} generate bundle --input-dir {{DEPLOY_DIR}}/ --version {{OPERATOR_VERSION}} --output-dir=bundle-ocp --package das-operator
+
+# Build and push developer bundle image
+build-push-developer-bundle: (_build-push-bundle "bundle.developer.Dockerfile")
+
+# Build and push the OCP bundle
+build-push-bundle: (_build-push-bundle "bundle-ocp.Dockerfile")
+
+# Private function to build and push a bundle image
+_build-push-bundle bundleDockerfile:
+	{{PODMAN}} build -f {{bundleDockerfile}} -t {{BUNDLE_IMAGE}} .
+	{{PODMAN}} push {{BUNDLE_IMAGE}}
+
+# Deploy CRDs and run operator locally for development
+run-local:
+	{{KUBECTL}} apply -f deploy/00_instaslice-operator.crd.yaml
+	{{KUBECTL}} apply -f deploy/00_node_allocationclaims.crd.yaml
+	{{KUBECTL}} apply -f deploy/00_nodeaccelerators.crd.yaml
+	{{KUBECTL}} apply -f deploy/01_namespace.yaml
+	{{KUBECTL}} apply -f deploy/01_operator_sa.yaml
+	{{KUBECTL}} apply -f deploy/02_operator_rbac.yaml
+	{{KUBECTL}} apply -f deploy/03_instaslice_operator.cr.yaml
+	RELATED_IMAGE_DAEMONSET_IMAGE={{DAEMONSET_IMAGE}} RELATED_IMAGE_WEBHOOK_IMAGE={{WEBHOOK_IMAGE}} RELATED_IMAGE_SCHEDULER_IMAGE={{SCHEDULER_IMAGE}} go run cmd/das-operator/main.go operator --namespace=das-operator
+
+# Run end-to-end tests with optional focus filter
+test-e2e e2e-args="-ginkgo.v" focus="":
+  #!/usr/bin/env bash
+
+  set -eoux pipefail
+
+  args=("{{e2e-args}}")
+  if [[ -n "{{focus}}" ]]; then
+    args+=("-ginkgo.focus={{focus}}")
+  fi
+
+  echo "=== Running e2e tests ==="
+  GOFLAGS=-mod=vendor go test ./test/e2e -v -count=1 -args ${args[@]}
+
+# Remove NVIDIA GPU operator from OpenShift
+undeploy-nvidia-ocp:
+  {{KUBECTL}} delete -f hack/manifests/gpu-cluster-policy.yaml
+  {{KUBECTL}} delete -f hack/manifests/nvidia-cpu-operator.yaml
+
+# Deploy NVIDIA GPU operator to OpenShift
+deploy-nvidia-ocp:
+  hack/deploy-nvidia.sh
+
+# Clean up all deployed Kubernetes resources
+undeploy:
+  @echo "=== Deleting K8s resources ==="
+  {{KUBECTL}} delete --ignore-not-found --wait=true -f {{DEPLOY_DIR}}/
+  # Wait for the operator namespace to be fully removed
+  {{KUBECTL}} wait --for=delete namespace/das-operator --timeout=120s || true
+
+# Deploy cert-manager for Kubernetes
+deploy-cert-manager:
+  export KUBECTL=$(KUBECTL) IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
+    hack/deploy-cert-manager.sh
+
+# Deploy cert-manager for OpenShift
+deploy-cert-manager-ocp:
+  {{KUBECTL}} apply -f hack/manifests/cert-manager-rh.yaml
+
+# Remove cert-manager from OpenShift
+undeploy-cert-manager-ocp:
+  {{KUBECTL}} delete -f hack/manifests/cert-manager-rh.yaml
+
+# Deploy Node Feature Discovery (NFD) operator for OpenShift
+deploy-nfd-ocp:
+  hack/deploy-nfd.sh
+
+# Run golangci-lint on the codebase
+lint:
+  {{GOLANGCI_LINT}} run --timeout 5m ./pkg/...
+
+# Run golangci-lint and automatically fix issues
+lint-fix: lint
+  {{GOLANGCI_LINT}} run --fix

--- a/Makefile
+++ b/Makefile
@@ -57,22 +57,6 @@ $(call verify-golang-versions,Dockerfile.ocp)
 $(call verify-golang-versions,Dockerfile.daemonset.ocp)
 endif
 
-GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.2.1
-golangci-lint:
-	@[ -f $(GOLANGCI_LINT) ] || { \
-	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
-	}
-
-.PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run --timeout 5m ./pkg/...
-
-.PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
-
 regen-crd:
 	go build -o _output/tools/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 	rm -f manifests/instaslice-operator.crd.yaml
@@ -91,18 +75,6 @@ regen-crd-k8s:
 	mv $(DEPLOY_DIR)/inference.redhat.com_dasoperators.yaml $(DEPLOY_DIR)/00_instaslice-operator.crd.yaml
 	mv $(DEPLOY_DIR)/inference.redhat.com_nodeaccelerators.yaml $(DEPLOY_DIR)/00_nodeaccelerators.crd.yaml
 
-build-images:
-	${PODMAN} build -f Dockerfile.ocp -t ${IMAGE_REGISTRY}/instaslice-operator:${IMAGE_TAG} .
-	${PODMAN} build -f Dockerfile.scheduler.ocp -t ${IMAGE_REGISTRY}/das-scheduler:${IMAGE_TAG} .
-	${PODMAN} build -f Dockerfile.daemonset.ocp -t ${IMAGE_REGISTRY}/das-daemonset:${IMAGE_TAG} .
-	${PODMAN} build -f Dockerfile.webhook.ocp -t ${IMAGE_REGISTRY}/das-webhook:${IMAGE_TAG} .
-
-build-push-images:
-	${PODMAN} push ${IMAGE_REGISTRY}/instaslice-operator:${IMAGE_TAG}
-	${PODMAN} push ${IMAGE_REGISTRY}/das-scheduler:${IMAGE_TAG}
-	${PODMAN} push ${IMAGE_REGISTRY}/das-daemonset:${IMAGE_TAG}
-	${PODMAN} push ${IMAGE_REGISTRY}/das-webhook:${IMAGE_TAG}
-
 generate: regen-crd regen-crd-k8s generate-clients
 .PHONY: generate
 
@@ -118,125 +90,3 @@ clean:
 	$(RM) -r ./_tmp
 .PHONY: clean
 
-.PHONY: deploy-das-k8s
-deploy-das-k8s:
-	${KUBECTL} label node $$(${KUBECTL} get nodes -o jsonpath='{.items[*].metadata.name}') \
-		nvidia.com/mig.capable=true --overwrite
-
-	@echo "=== Deploying Cert Manager ==="
-	$(MAKE) deploy-cert-manager
-
-	@echo "=== Generating CRDs for K8s ==="
-	$(MAKE) regen-crd-k8s
-
-	@echo "=== Applying K8s CRDs ==="
-	       ${KUBECTL} apply -f $(DEPLOY_DIR)/00_instaslice-operator.crd.yaml \
-                      -f $(DEPLOY_DIR)/00_nodeaccelerators.crd.yaml
-
-	@echo "=== Waiting for CRDs to be established ==="
-	${KUBECTL} wait --for=condition=established --timeout=60s \
-                     crd dasoperators.inference.redhat.com
-
-	@echo "=== Applying K8s core manifests ==="
-	@echo "=== Setting emulatedMode to $(EMULATED_MODE) in CR ==="
-	TMP_DIR=$$(mktemp -d); \
-	cp $(DEPLOY_DIR)/*.yaml $$TMP_DIR/; \
-       sed -i 's/emulatedMode: .*/emulatedMode: "$(EMULATED_MODE)"/' $$TMP_DIR/03_instaslice_operator.cr.yaml; \
-       env IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG) envsubst < $(DEPLOY_DIR)/04_deployment.yaml > $$TMP_DIR/04_deployment.yaml; \
-       ${KUBECTL} apply -f $$TMP_DIR/
-
-.PHONY: emulated-k8s
-emulated-k8s: EMULATED_MODE=enabled
-emulated-k8s: build-push-images-parallel deploy-das-k8s
-
-.PHONY: cleanup-k8s
-cleanup-k8s:
-	@echo "=== Deleting K8s resources ==="
-	${KUBECTL} delete --ignore-not-found --wait=true -f $(DEPLOY_DIR)/
-	# Wait for the operator namespace to be fully removed
-	${KUBECTL} wait --for=delete namespace/das-operator --timeout=120s || true
-
-
-.PHONY: cleanup-ocp
-cleanup-ocp:
-	@echo "=== Deleting OCP resources ==="
-	${KUBECTL} delete --ignore-not-found --wait=true -f $(DEPLOY_DIR)/
-	# Wait for the operator namespace to be fully removed
-	${KUBECTL} wait --for=delete namespace/das-operator --timeout=120s || true
-
-.PHONY: deploy-cert-manager
-deploy-cert-manager:
-	export KUBECTL=$(KUBECTL) IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
-		hack/deploy-cert-manager.sh
-
-.PHONY: deploy-cert-manager-ocp
-deploy-cert-manager-ocp:
-	${KUBECTL} apply -f hack/manifests/cert-manager-rh.yaml
-
-.PHONY: undeploy-cert-manager-ocp
-undeploy-cert-manager-ocp:
-	${KUBECTL} delete -f hack/manifests/cert-manager-rh.yaml
-
-.PHONY: deploy-nfd-ocp
-deploy-nfd-ocp:
-	hack/deploy-nfd.sh
-
-.PHONY: undeploy-nfd-ocp
-undeploy-nfd-ocp:
-	${KUBECTL} delete -f hack/manifests/nfd-instance.yaml
-	${KUBECTL} delete -f hack/manifests/nfd.yaml
-
-.PHONY: deploy-nvidia-ocp
-deploy-nvidia-ocp:
-	hack/deploy-nvidia.sh
-
-.PHONY: undeploy-nvidia-ocp
-undeploy-nvidia-ocp:
-	${KUBECTL} delete -f hack/manifests/gpu-cluster-policy.yaml
-	${KUBECTL} delete -f hack/manifests/nvidia-cpu-operator.yaml
-
-TEST_E2E_ARGS := -ginkgo.v
-ifdef FOCUS
-TEST_E2E_ARGS += -ginkgo.focus=$(FOCUS)
-endif
-
-.PHONY: test-e2e
-test-e2e:
-	@echo "=== Running e2e tests ==="
-	GOFLAGS=-mod=vendor go test ./test/e2e -v -count=1 -args $(TEST_E2E_ARGS)
-
-.PHONY: operator-sdk
-operator-sdk:
-	@[ -f $(OPERATOR_SDK) ] || { \
-	set -e ;\
-	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH};\
-	chmod +x $(OPERATOR_SDK) ;\
-	}
-
-.PHONY: bundle-generate
-bundle-generate: operator-sdk
-	$(OPERATOR_SDK) generate bundle --input-dir $(DEPLOY_DIR)/ --version $(OPERATOR_VERSION) --output-dir=bundle-ocp --package das-operator
-
-.PHONY: bundle-build
-bundle-build: bundle-generate
-	$(PODMAN) build -f bundle-ocp.Dockerfile -t $(BUNDLE_IMAGE) .
-
-.PHONY: bundle-push
-bundle-push:
-	$(PODMAN) push $(BUNDLE_IMAGE)
-
-
-run-local: export DAEMONSET_IMAGE="${IMAGE_REGISTRY}/das-daemonset:${IMAGE_TAG}"
-run-local: export WEBHOOK_IMAGE="${IMAGE_REGISTRY}/das-webhook:${IMAGE_TAG}"
-run-local: export SCHEDULER_IMAGE="${IMAGE_REGISTRY}/das-scheduler:${IMAGE_TAG}"
-run-local:
-	${KUBECTL} apply -f deploy/00_instaslice-operator.crd.yaml
-	${KUBECTL} apply -f deploy/00_node_allocationclaims.crd.yaml
-	${KUBECTL} apply -f deploy/00_nodeaccelerators.crd.yaml
-	${KUBECTL} apply -f deploy/01_namespace.yaml
-	${KUBECTL} apply -f deploy/01_operator_sa.yaml
-	${KUBECTL} apply -f deploy/02_operator_rbac.yaml
-	${KUBECTL} apply -f deploy/03_instaslice_operator.cr.yaml
-	RELATED_IMAGE_DAEMONSET_IMAGE=${DAEMONSET_IMAGE} RELATED_IMAGE_WEBHOOK_IMAGE=${WEBHOOK_IMAGE} RELATED_IMAGE_SCHEDULER_IMAGE=${SCHEDULER_IMAGE} go run cmd/das-operator/main.go operator --kubeconfig=${KUBECONFIG} --namespace=das-operator

--- a/related_images.developer.json
+++ b/related_images.developer.json
@@ -16,7 +16,7 @@
     "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next@sha256:c60de815054b60127155c19cd4e2d8d8456e991a31bd5a890f03e529e46435e5"
   },
   {
-    "name": "instaslice-operator-bundle-public-next",
+    "name": "instaslice-operator-bundle-next",
     "image": "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-bundle-developer-next@sha256:61ff013dee3bcc9b736f9aefc9042c02fe614f7d180c52c4b816c71a0c510141"
   }
 ]


### PR DESCRIPTION
```
❯ just
Available recipes:
    build-push-bundle                      # Build and push the OCP bundle
    build-push-daemonset                   # Build and push daemonset image
    build-push-developer-bundle            # Build and push developer bundle image
    build-push-operator                    # Build and push operator image
    build-push-parallel                    # Build and push all container images in parallel
    build-push-scheduler                   # Build and push scheduler image
    build-push-webhook                     # Build and push webhook image
    bundle-generate                        # Generate operator bundle using operator-sdk
    default                                # Default target - shows available commands and environment info
    deploy-cert-manager                    # Deploy cert-manager for Kubernetes
    deploy-cert-manager-ocp                # Deploy cert-manager for OpenShift
    deploy-das-ocp                         # Deploy DAS on OpenShift Container Platform
    deploy-nfd-ocp                         # Deploy Node Feature Discovery (NFD) operator for OpenShift
    deploy-nvidia-ocp                      # Deploy NVIDIA GPU operator to OpenShift
    info                                   # Display environment and image configuration information
    lint                                   # Run all linting (markdown and Go)
    lint-fix                               # Run all linting fixes (markdown and Go)
    lint-go                                # Run golangci-lint on the codebase
    lint-go-fix                            # Run golangci-lint and automatically fix issues
    lint-md                                # Run markdownlint on markdown files
    lint-md-fix                            # Run markdownlint and automatically fix issues
    regen-crd-k8s                          # Regenerate Custom Resource Definitions (CRDs) for Kubernetes
    run-local                              # Deploy CRDs and run operator locally for development
    test-e2e e2e-args="-ginkgo.v" focus="" # Run end-to-end tests with optional focus filter
    undeploy                               # Clean up all deployed Kubernetes resources
    undeploy-cert-manager-ocp              # Remove cert-manager from OpenShift
    undeploy-nvidia-ocp                    # Remove NVIDIA GPU operator from OpenShift

Related Images: related_images.json

    Operator Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-operator-next@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768
     Webhook Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-next@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41
   Scheduler Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-next@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e
   Daemonset Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-next@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc
     Emulated Mode: disabled
```