### PR TITLE
Justfile: wait for CRDs before applying other resources

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -58,7 +58,7 @@ deploy-das-ocp: info regen-crd-k8s
   echo "Rewriting Emulated Mode"
   sed -i "s/emulatedMode: .*/emulatedMode: \"${EMULATED_MODE}\"/" ${TMP_DIR}/03_instaslice_operator.cr.yaml
 
-  {{KUBECTL}} apply -f ${TMP_DIR}/
+  hack/deploy-das-ocp.sh ${TMP_DIR}
 
 # Regenerate Custom Resource Definitions (CRDs) for Kubernetes
 regen-crd-k8s:

--- a/hack/deploy-das-ocp.sh
+++ b/hack/deploy-das-ocp.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+TMP_DIR="$1"
+
+echo "Applying CRDs..."
+CRD_FILES=$(find ${TMP_DIR} -name "*.yaml" \( -name "*.crd.yaml" -o -exec grep -l "kind: CustomResourceDefinition" {} \; \) | sort -u)
+if [ -n "$CRD_FILES" ]; then
+  for crd_file in $CRD_FILES; do
+    echo "Applying CRD: $(basename $crd_file)"
+    ${KUBECTL} apply -f "$crd_file"
+  done
+  
+  echo "Waiting for CRDs to be established..."
+  APPLIED_CRDS=$(for crd_file in $CRD_FILES; do
+    awk '/^metadata:/{p=1} p && /^  name:/{print $2; p=0}' "$crd_file"
+  done | sort -u)
+  for crd_name in $APPLIED_CRDS; do
+    if [ -n "$crd_name" ]; then
+      echo "Waiting for CRD: $crd_name"
+      ${KUBECTL} wait --for condition=established --timeout=60s crd/$crd_name || echo "Warning: Failed to wait for CRD $crd_name"
+    fi
+  done
+else
+  echo "No CRDs found to apply."
+fi
+
+# Now apply the remaining resources in numerical order, auto-discovering all prefixes.  
+echo "Applying remaining resources..."
+ALL_PREFIXES=$(find ${TMP_DIR} -name "[0-9][0-9]_*.yaml" | sed 's/.*\/\([0-9][0-9]\)_.*/\1/' | sort -u)
+for prefix in $ALL_PREFIXES; do
+  PREFIX_FILES=$(find ${TMP_DIR} -name "${prefix}_*.yaml" | sort)
+  for file in $PREFIX_FILES; do
+    echo "Applying: $(basename $file)"
+    ${KUBECTL} apply -f "$file"
+  done
+done
+
+echo "DAS operator deployed successfully!" 


### PR DESCRIPTION
This fixes a race condition where other resources within deploy are applied before the corresponding CRDs are ready.
```sh
$  just deploy-das-ocp

Related Images: related_images.json

    Operator Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-rhel9-operator@sha256:bdb717d5154bef8b3bedd1ae240f76951bac3d28ea56c107dc0cc9ebdc956768
     Webhook Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-webhook-rhel9@sha256:85108eabb38e3ae313021c49ee5887fa025783b3a080d75ac3cdffb4d2016c41
   Scheduler Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-scheduler-rhel9@sha256:00e7b2e06f2cf7062878d83404623f7986bcc2a4fcc9179f82ac9ee2a7f9a74e
   Daemonset Image: registry.redhat.io/dynamic-accelerator-slicer-tech-preview/instaslice-daemonset-rhel9@sha256:912be6ada44548de7b124e327cdcef0869181f316a9d3c22594f30f2206c91bc
     Emulated Mode: enabled

Generating CRDs into deploy directory
go build -o _output/tools/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
rm -f deploy/00_instaslice-operator.crd.yaml
rm -f deploy/00_nodeaccelerators.crd.yaml
./_output/tools/bin/controller-gen crd paths=./pkg/apis/dasoperator/v1alpha1/... schemapatch:manifests=./manifests output:crd:dir=./deploy
mv deploy/inference.redhat.com_dasoperators.yaml deploy/00_instaslice-operator.crd.yaml
mv deploy/inference.redhat.com_nodeaccelerators.yaml deploy/00_nodeaccelerators.crd.yaml
Rewriting Operator Image
Rewriting Webhook Image
Rewriting Scheduler Image
Rewriting Daemonset Image
Rewriting Emulated Mode
customresourcedefinition.apiextensions.k8s.io/dasoperators.inference.redhat.com created
customresourcedefinition.apiextensions.k8s.io/allocationclaims.inference.redhat.com created
customresourcedefinition.apiextensions.k8s.io/nodeaccelerators.inference.redhat.com created
namespace/das-operator created
serviceaccount/das-operator created
clusterrole.rbac.authorization.k8s.io/das-operator created
clusterrolebinding.rbac.authorization.k8s.io/das-operator created
clusterrolebinding.rbac.authorization.k8s.io/das-operator-privileged-scc created
role.rbac.authorization.k8s.io/das-operator created
rolebinding.rbac.authorization.k8s.io/das-operator created
clusterrolebinding.rbac.authorization.k8s.io/das-operator-authentication-reader created
deployment.apps/das-operator created
customresourcedefinition.apiextensions.k8s.io/allocationclaims.inference.redhat.com configured
error: resource mapping not found for name: "cluster" namespace: "das-operator" from "/tmp/tmp.GTaXpjVzS9/03_instaslice_operator.cr.yaml": no matches for kind "DASOperator" in version "inference.redhat.com/v1alpha1"
ensure CRDs are installed first
error: Recipe `deploy-das-ocp` failed with exit code 1
```