### PR TITLE
Fix passing emulated mode with just

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -116,14 +116,25 @@ _build-push-bundle bundleDockerfile:
 
 # Deploy CRDs and run operator locally for development
 run-local:
-  {{KUBECTL}} apply -f deploy/00_instaslice-operator.crd.yaml
-  {{KUBECTL}} apply -f deploy/00_node_allocationclaims.crd.yaml
-  {{KUBECTL}} apply -f deploy/00_nodeaccelerators.crd.yaml
-  {{KUBECTL}} apply -f deploy/01_namespace.yaml
-  {{KUBECTL}} apply -f deploy/01_operator_sa.yaml
-  {{KUBECTL}} apply -f deploy/02_operator_rbac.yaml
-  {{KUBECTL}} apply -f deploy/03_instaslice_operator.cr.yaml
-  RELATED_IMAGE_DAEMONSET_IMAGE={{DAEMONSET_IMAGE}} RELATED_IMAGE_WEBHOOK_IMAGE={{WEBHOOK_IMAGE}} RELATED_IMAGE_SCHEDULER_IMAGE={{SCHEDULER_IMAGE}} go run cmd/das-operator/main.go operator --namespace=das-operator --kubeconfig="{{KUBECONFIG}}"
+  #!/usr/bin/env bash
+
+  set -eou pipefail
+
+  TMP_DIR=$(mktemp -d)
+  cp ${DEPLOY_DIR}/*.yaml ${TMP_DIR}/
+
+  sed -i "s/emulatedMode: .*/emulatedMode: \"${EMULATED_MODE}\"/" ${TMP_DIR}/03_instaslice_operator.cr.yaml
+
+  {{KUBECTL}} apply -f ${TMP_DIR}/00_instaslice-operator.crd.yaml
+  {{KUBECTL}} apply -f ${TMP_DIR}/00_node_allocationclaims.crd.yaml
+  {{KUBECTL}} apply -f ${TMP_DIR}/00_nodeaccelerators.crd.yaml
+  {{KUBECTL}} apply -f ${TMP_DIR}/01_namespace.yaml
+  {{KUBECTL}} apply -f ${TMP_DIR}/01_operator_sa.yaml
+  {{KUBECTL}} apply -f ${TMP_DIR}/02_operator_rbac.yaml
+  {{KUBECTL}} apply -f ${TMP_DIR}/03_instaslice_operator.cr.yaml
+
+  RELATED_IMAGE_DAEMONSET_IMAGE={{DAEMONSET_IMAGE}} RELATED_IMAGE_WEBHOOK_IMAGE={{WEBHOOK_IMAGE}} RELATED_IMAGE_SCHEDULER_IMAGE={{SCHEDULER_IMAGE}} \
+  go run cmd/das-operator/main.go operator --namespace=das-operator --kubeconfig="{{KUBECONFIG}}"
 
 # Run end-to-end tests with optional focus filter
 test-e2e e2e-args="-ginkgo.v" focus="":

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ For local development:
    # Build and push images first
    just build-push-parallel
 
-   # Or run operator locally
-   just run-local
+   # Run operator locally
+   # Set EMULATED_MODE to control hardware emulation
+   EMULATED_MODE=enabled just run-local
    ```
 
 2. **Run tests**:
@@ -302,7 +303,8 @@ just info
 Run the operator locally for development:
 
 ```bash
-just run-local
+# Set EMULATED_MODE to 'enabled' for simulated GPUs or 'disabled' for real hardware
+EMULATED_MODE=enabled just run-local
 ```
 
 Run end-to-end tests:


### PR DESCRIPTION
This change ensures emulated mode is passed when deployed using run-local. 