### PR TITLE
Minor fix to Justfile to avoid shell() function

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,11 +9,11 @@ export GOLANGCI_LINT:= env('GOLANGCI_LINT', 'golangci-lint')
 export MARKDOWNLINT := env('MARKDOWNLINT', 'markdownlint')
 export KUBECONFIG := env('KUBECONFIG', '')
 
-export OPERATOR_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-next") | .image' $1""", RELATED_IMAGES)
-export WEBHOOK_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-webhook-next") | .image' $1""", RELATED_IMAGES)
-export SCHEDULER_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-scheduler-next") | .image' $1""", RELATED_IMAGES)
-export DAEMONSET_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-daemonset-next") | .image' $1""", RELATED_IMAGES)
-export BUNDLE_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-bundle-next") | .image' $1""", RELATED_IMAGES)
+export OPERATOR_IMAGE := `jq -r '.[] | select(.name == "instaslice-operator-next") | .image' {{RELATED_IMAGES}}`
+export WEBHOOK_IMAGE := `jq -r '.[] | select(.name == "instaslice-webhook-next") | .image' {{RELATED_IMAGES}}`
+export SCHEDULER_IMAGE := `jq -r '.[] | select(.name == "instaslice-scheduler-next") | .image' {{RELATED_IMAGES}}`
+export DAEMONSET_IMAGE := `jq -r '.[] | select(.name == "instaslice-daemonset-next") | .image' {{RELATED_IMAGES}}`
+export BUNDLE_IMAGE := `jq -r '.[] | select(.name == "instaslice-operator-bundle-next") | .image' {{RELATED_IMAGES}}`
 
 export OPERATOR_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-operator-next:latest"
 export WEBHOOK_IMAGE_ORIGINAL := "quay.io/redhat-user-workloads/dynamicacceleratorsl-tenant/instaslice-webhook-next:latest"


### PR DESCRIPTION
Encountered an issue in a rehearse job while enabling pre-submits for instaslice-operator as follows:
```
error: Call to unknown function `shell`
  ——▶ Justfile:11:26
   │
11 │ export OPERATOR_IMAGE := shell("""jq -r '.[] | select(.name == "instaslice-operator-next") | .image' $1""", RELATED_IMAGES)
   │                          ^^^^^
```
Job Ref: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/67061/rehearse-67061-pull-ci-openshift-instaslice-operator-next-e2e-sno-gpu/1945142605058674688 

Hence modified the content to use backticks `` instead of `shell()`

/cc @rphillips @harche 