### PR TITLE
fix regex for dockerfiles in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,7 @@
       {
         "matchFileNames": [
           "Dockerfile.*",
-          "*.Dockerfile"
+          ".*Dockerfile"
         ],
         "automerge": true,
         "addLabels": [


### PR DESCRIPTION
The glob support for renovate does not think *.Dockerfile is a glob, but a regex.