### PR TITLE
Possible resolution to the RBAC issue while executing e2e tests in CI

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -76,17 +76,18 @@ const (
 )
 
 var _ = BeforeSuite(func() {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		}
-		cfg, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			Skip("kubernetes config not available: " + err.Error())
-		}
+	//(TODO) Remove the deadcode if this resolves rbac issue while executing e2e test suite in CI
+	// cfg, err := rest.InClusterConfig()
+	// if err != nil {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		Skip("kubernetes config not available: " + err.Error())
+	}
+	//}
 
 	// TODO - Remove this warning suppression once the webhook starts working properly
 	cfg.WarningHandler = rest.NoWarnings{}


### PR DESCRIPTION
- CI env runs on an Opneshift CI cluster
- The `rest.InClusterConfig()` call might pick the config of the Openshift CI cluster instead of the SNO's
- This change could potentially resolve the issue

/cc @harche @sohankunkerkar 