### PR TITLE
* : address rbac permissions issue with scheduler and fix daemonset race

### DIFF
--- a/deploy/03_scheduler_rbac.yaml
+++ b/deploy/03_scheduler_rbac.yaml
@@ -29,17 +29,6 @@ rules:
       - "patch"
       - "create"
       - "delete"
-  - apiGroups: ["storage.k8s.io"]
-    resources:
-      - csinodes
-      - csidrivers
-      - csistoragecapacities
-      - storageclasses
-      - volumeattachments
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -55,28 +44,6 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: das-scheduler
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: das-scheduler-node-reader
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get","list","watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: das-scheduler-node-reader-binding
-subjects:
-  - kind: ServiceAccount
-    name: das-scheduler
-    namespace: das-operator
-roleRef:
-  kind: ClusterRole
-  name: das-scheduler-node-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/deploy-das-ocp.sh
+++ b/hack/deploy-das-ocp.sh
@@ -37,4 +37,10 @@ for prefix in $ALL_PREFIXES; do
   done
 done
 
-echo "DAS operator deployed successfully!" 
+echo "DAS operator deployed successfully!"
+
+# Clean up generated files after successful deployment.
+echo "Cleaning up generated files..."
+rm -rf config/ 2>/dev/null || true
+rm -f deploy/inference.redhat.com_allocationclaims.yaml 2>/dev/null || true
+echo "Cleanup completed!" 


### PR DESCRIPTION
This PR fixes the following things:
- daemonset restart due to `NodeAccelerator` resource version conflict.
- Address rbac permissions from https://github.com/openshift/instaslice-operator/pull/763
- Clean up generated files after the das deployment 

```sh
$ oc get po -n das-operator
NAME                                    READY   STATUS    RESTARTS   AGE
das-daemonset-gq4xd                     1/1     Running   0          5m18s
das-operator-57d488457d-f7pcw           1/1     Running   0          5m20s
das-operator-57d488457d-nqtsv           1/1     Running   0          5m20s
das-operator-webhook-7f66f5c477-svhg4   1/1     Running   0          5m18s
das-operator-webhook-7f66f5c477-tlzbp   1/1     Running   0          5m18s
das-scheduler-59977778f-bp9p4           1/1     Running   0          5m18s
das-scheduler-59977778f-qjdm2           1/1     Running   0          5m18s

```