### PR TITLE
Add anti-affinity to the scheduler, webhook and controller pods

### DIFF
--- a/bindata/assets/instaslice-operator/scheduler_deployment.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_deployment.yaml
@@ -13,6 +13,15 @@ spec:
       labels:
         app: das-scheduler
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: das-scheduler
       serviceAccountName: das-scheduler
       containers:
       - name: scheduler

--- a/bindata/assets/instaslice-operator/webhook-deployment.yaml
+++ b/bindata/assets/instaslice-operator/webhook-deployment.yaml
@@ -32,14 +32,14 @@ spec:
         app.kubernetes.io/version: 0.0.1
     spec:
       affinity:
-        podAffinity:
+        podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
+          - weight: 100
+            podAffinityTerm:
               topologyKey: kubernetes.io/hostname
               labelSelector:
                 matchLabels:
-                  app.kubernetes.io/part-of: das-operator
-            weight: 100
+                  app.kubernetes.io/name: das-operator-webhook
       automountServiceAccountToken: false
       containers:
       - command:

--- a/bundle-ocp/manifests/das-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/das-operator.clusterserviceversion.yaml
@@ -264,7 +264,7 @@ spec:
                 app: das-operator
             spec:
               affinity:
-                podAffinity:
+                podAntiAffinity:
                   preferredDuringSchedulingIgnoredDuringExecution:
                   - podAffinityTerm:
                       labelSelector:

--- a/deploy/04_deployment.yaml
+++ b/deploy/04_deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: das-operator
     spec:
       affinity:
-        podAffinity:
+        podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
               topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
This ensures the replicas of the secondary scheduler, webhook and the controller pods are spread across the nodes. 