### PR TITLE
make the webhook mandatory

### DIFF
--- a/bindata/assets/instaslice-operator/webhook.yaml
+++ b/bindata/assets/instaslice-operator/webhook.yaml
@@ -20,7 +20,7 @@ webhooks:
       namespace: das-operator
       path: /mutate-pod
       port: 8443
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: instaslice.redhat.com
   namespaceSelector:
     matchExpressions:


### PR DESCRIPTION
Do not admit pods without the webhook mutating them. 