### PR TITLE
remove the EMULATED_MODE variable from daemonset

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -213,8 +213,7 @@ undeploy:
 # Deploy cert-manager for Kubernetes
 [group('deploy')]
 deploy-cert-manager:
-    export KUBECTL=$(KUBECTL) IMG=$(IMG) IMG_DMST=$(IMG_DMST) && \
-      hack/deploy-cert-manager.sh
+    hack/deploy-cert-manager.sh
 
 # Deploy cert-manager for OpenShift
 [group('deploy')]

--- a/bindata/assets/instaslice-operator/daemonset.yaml
+++ b/bindata/assets/instaslice-operator/daemonset.yaml
@@ -54,8 +54,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: EMULATED_MODE
-            value: "false"
           - name: NVIDIA_MIG_CONFIG_DEVICES
             value: "all"
         lifecycle:

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -293,10 +293,11 @@ func (c *TargetConfigReconciler) manageDaemonset(ctx context.Context, ownerRefer
 		if c.targetDaemonsetImage != "" {
 			required.Spec.Template.Spec.Containers[i].Image = c.targetDaemonsetImage
 		}
-		for j := range required.Spec.Template.Spec.Containers[i].Env {
-			if required.Spec.Template.Spec.Containers[i].Env[j].Name == "EMULATED_MODE" {
-				required.Spec.Template.Spec.Containers[i].Env[j].Value = fmt.Sprintf("%v", c.emulatedMode)
-			}
+		if c.emulatedMode == slicev1alpha1.EmulatedModeEnabled {
+			required.Spec.Template.Spec.Containers[i].Env = append(required.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+				Name:  "EMULATED_MODE",
+				Value: slicev1alpha1.EmulatedModeEnabled,
+			})
 		}
 	}
 	return resourceapply.ApplyDaemonSet(ctx,


### PR DESCRIPTION
This PR removes EMULATED_MODE from the environment within the daemonset yaml. You have to enable it via the operator. The operator will inject the EMULATED_MODE env variable into the yaml if necessary. 