### PR TITLE
Device plugin should wait for the nvidia gpu operator to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,10 @@ The plugin integrates with the Kubernetes scheduler and runs through three frame
 
 Once promoted, the device plugin provisions the slices.
 
+The daemonset advertises GPU resources only after the NVIDIA GPU Operator's
+`ClusterPolicy` reports a **Ready** state. This prevents the scheduler from
+scheduling pods on a node before the GPU Operator has initialized the drivers.
+
 ### AllocationClaim resource
 
 `AllocationClaim` is a namespaced CRD that records which MIG slice will be prepared for a pod. Claims start in the
@@ -636,6 +640,15 @@ You can focus on specific tests:
 ```bash
 just test-e2e focus="GPU slices"
 ```
+
+### Known Issues
+
+Due to [kubernetes/kubernetes#128043](https://github.com/kubernetes/kubernetes/issues/128043)
+pods may enter an `UnexpectedAdmissionError` state if admission fails. Pods
+managed by higher level controllers such as Deployments will be recreated
+automatically. Naked pods, however, must be cleaned up manually with
+`kubectl delete pod`. Using controllers is recommended until the upstream issue
+is resolved.
 
 ## Uninstalling
 

--- a/deploy/02_operator_rbac.yaml
+++ b/deploy/02_operator_rbac.yaml
@@ -151,14 +151,22 @@ rules:
   - apiGroups:
     - cert-manager.io
     resources:
-    - certificates
-    - issuers
+      - certificates
+      - issuers
     verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
+      - create
+      - get
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - nvidia.com
+    resources:
+      - clusterpolicies
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
     - events.k8s.io
     resources:

--- a/pkg/daemonset/deviceplugins/clusterpolicy.go
+++ b/pkg/daemonset/deviceplugins/clusterpolicy.go
@@ -1,0 +1,50 @@
+package deviceplugins
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+func waitForClusterPolicy(ctx context.Context, dynClient dynamic.Interface) error {
+	gvr := schema.GroupVersionResource{Group: "nvidia.com", Version: "v1", Resource: "clusterpolicies"}
+	return wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		obj, err := dynClient.Resource(gvr).Get(ctx, "gpu-cluster-policy", metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.InfoS("Waiting for ClusterPolicy", "name", "gpu-cluster-policy")
+				return false, nil
+			}
+			klog.ErrorS(err, "failed to get ClusterPolicy")
+			return false, nil
+		}
+
+		state, _, _ := unstructured.NestedString(obj.Object, "status", "state")
+		if strings.EqualFold(state, "ready") {
+			return true, nil
+		}
+
+		if conds, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions"); found {
+			for _, c := range conds {
+				if m, ok := c.(map[string]interface{}); ok {
+					t, _, _ := unstructured.NestedString(m, "type")
+					st, _, _ := unstructured.NestedString(m, "status")
+					if t == "Ready" && strings.EqualFold(st, "True") {
+						return true, nil
+					}
+				}
+			}
+		}
+
+		klog.InfoS("Nvidia GPU Operator ClusterPolicy not ready", "state", state)
+		return false, nil
+	})
+}

--- a/pkg/daemonset/deviceplugins/discovery.go
+++ b/pkg/daemonset/deviceplugins/discovery.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	applyconfigurationmetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	dynamic "k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 )
 
@@ -85,14 +86,16 @@ func (e *EmulatedMigGpuDiscoverer) Discover() (*instav1.NodeAccelerator, error) 
 
 // RealMigGpuDiscoverer implements MigGpuDiscoverer for real hardware.
 type RealMigGpuDiscoverer struct {
-	ctx         context.Context
-	nodeName    string
-	instaClient v1alpha1.NodeAcceleratorInterface
+	ctx           context.Context
+	nodeName      string
+	instaClient   v1alpha1.NodeAcceleratorInterface
+	dynamicClient dynamic.Interface
 }
 
 var _ MigGpuDiscoverer = &RealMigGpuDiscoverer{}
 
 func (r *RealMigGpuDiscoverer) Discover() (*instav1.NodeAccelerator, error) {
+
 	if err := EnsureNvmlInitialized(); err != nil {
 		klog.ErrorS(err, "NVML initialization failed")
 		return nil, err


### PR DESCRIPTION
After the reboot, before publishing node allocatables for the MIG slices, the daemonset should wait for the Nvidia GPU Operator to come up before starting the slice specific device plugins. 