### PR TITLE
generate bundle from an empty bundle-ocp folder

### DIFF
--- a/deploy/01_operator_use_privileged_scc.yaml
+++ b/deploy/01_operator_use_privileged_scc.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: das-operator-privileged-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: das-operator
+  namespace: das-operator


### PR DESCRIPTION
we can't place a manifest yaml in the output directory `bundle-ocp`, pipeline tool can create the bundle from an empty output folder.

All manifests we want to be included in the generated csv/bundle should be placed in the deploy folder, and the `bundle generate` command will copy it to the output folder appropriately.

 