### PR TITLE
rbac: align scheduler ClusterRole permissions with operator RBAC

### DIFF
--- a/bindata/assets/instaslice-operator/scheduler_rbac.clusterrole.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_rbac.clusterrole.yaml
@@ -61,8 +61,6 @@ rules:
   - events
   verbs:
   - create
-  - patch
-  - update
 - apiGroups:
   - inference.redhat.com
   resources:


### PR DESCRIPTION
This resolves the issue where webhook and scheduler pods were not deploying due to the operator lacking permissions to manage the scheduler ClusterRole.