### PR TITLE
change ubi-micro to ubi-minimal for fips

### DIFF
--- a/Dockerfile.daemonset.ocp
+++ b/Dockerfile.daemonset.ocp
@@ -31,7 +31,7 @@ LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
 
-LABEL io.openshift.tags=""
+LABEL io.openshift.tags="das,accelerator,dynamic,instaslice,slicer"
 # Licenses
 
 COPY LICENSE /licenses/LICENSE

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY . .
 RUN GO_BUILD_PACKAGES=./cmd/das-operator make
 
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:666b64ba2670d356b03dd977fe1931c35fd624add9d8ef57e9dbd8f2a47118ba
+FROM registry.redhat.io/ubi9/ubi-minimal@sha256:67fee1a132e8e326434214b3c7ce90b2500b2ad02c9790cc61581feb58d281d5
 WORKDIR /
 COPY --from=build /workspace/das-operator /usr/bin
 USER 65532:65532
@@ -24,6 +24,7 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
+LABEL io.openshift.tags="das,accelerator,dynamic,instaslice,slicer"
 
 # Licenses
 

--- a/Dockerfile.scheduler.ocp
+++ b/Dockerfile.scheduler.ocp
@@ -8,7 +8,7 @@ ENV GOFLAGS=-mod=mod
 RUN GO_BUILD_PACKAGES=./cmd/das-scheduler make
 
 # runtime stage
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:666b64ba2670d356b03dd977fe1931c35fd624add9d8ef57e9dbd8f2a47118ba
+FROM registry.redhat.io/ubi9/ubi-minimal@sha256:67fee1a132e8e326434214b3c7ce90b2500b2ad02c9790cc61581feb58d281d5
 
 WORKDIR /
 COPY --from=build /workspace/das-scheduler /usr/bin
@@ -29,6 +29,7 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
+LABEL io.openshift.tags="das,accelerator,dynamic,instaslice,slicer"
 
 # Licenses
 COPY LICENSE /licenses/LICENSE

--- a/Dockerfile.webhook.ocp
+++ b/Dockerfile.webhook.ocp
@@ -4,7 +4,7 @@ WORKDIR /workspace
 COPY . .
 RUN GO_BUILD_PACKAGES=./cmd/das-webhook make
 
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:666b64ba2670d356b03dd977fe1931c35fd624add9d8ef57e9dbd8f2a47118ba
+FROM registry.redhat.io/ubi9/ubi-minimal@sha256:67fee1a132e8e326434214b3c7ce90b2500b2ad02c9790cc61581feb58d281d5
 WORKDIR /
 COPY --from=build /workspace/das-webhook /usr/bin
 USER 65532:65532
@@ -24,6 +24,7 @@ LABEL url="https://access.redhat.com/"
 LABEL vendor="Red Hat, Inc."
 LABEL version="1"
 LABEL maintainer="Red Hat"
+LABEL io.openshift.tags="das,accelerator,dynamic,instaslice,slicer"
 
 # Licenses
 

--- a/bundle-ocp.Dockerfile
+++ b/bundle-ocp.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi:9.6 as builder
+FROM registry.redhat.io/ubi9/ubi@sha256:dc29e0ceb72fd8d28e6caad981d7487b8996a601441efe03b1d7f9bda893e83b as builder
 RUN dnf -y install jq
 
 ARG RELATED_IMAGE_FILE=related_images.json


### PR DESCRIPTION
We should use ubi-minimal so that we are somewhat fips compliant even if we are not fully compliant.  Also switched repos to public version where available.

Additions:  added io.openshift.tags to resolve EC errors and inheriting them from base image
