### PR TITLE
deploy scripts cleanup

### DIFF
--- a/hack/deploy-nfd.sh
+++ b/hack/deploy-nfd.sh
@@ -72,6 +72,6 @@ if [ $_apiReady -eq 0 ]; then
 fi
 echo "nfd-operator installed successfully"
 
-oc get csv -n openshift-nfd $CSVName -o jsonpath='{.metadata.annotations.alm-examples}' | jq '.[0]' >/tmp/nodefeaturediscovery.json
+oc get csv -n openshift-nfd $CSVName -o jsonpath='{.metadata.annotations.alm-examples}' |  jq '.[] | select(.kind=="NodeFeatureDiscovery")' >/tmp/nodefeaturediscovery.json
 oc apply -f /tmp/nodefeaturediscovery.json
 oc wait nodefeaturediscovery -n openshift-nfd --for=condition=Available --timeout=15m --all

--- a/hack/deploy-nvidia.sh
+++ b/hack/deploy-nvidia.sh
@@ -76,7 +76,7 @@ _wait_for_apiserver() {
 }
 
 echo "Applying Nvidia"
-_kubectl apply -f hack/manifests/nvidia-cpu-operator.yaml
+_kubectl apply -f hack/manifests/nvidia-gpu-operator.yaml
 echo "Waiting for Nvidia for ${TIMEOUT}"
 _wait_for_pods_to_exist nvidia-gpu-operator gpu-operator ${TIMEOUT}
 _kubectl wait --for condition=established --timeout=300s crd/clusterpolicies.nvidia.com

--- a/hack/manifests/nvidia-gpu-operator.yaml
+++ b/hack/manifests/nvidia-gpu-operator.yaml
@@ -19,11 +19,9 @@ metadata:
   name: gpu-operator-certified
   namespace: nvidia-gpu-operator
 spec:
-  channel: "v24.9"
   installPlanApproval: Automatic
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "gpu-operator-certified.v24.9.2"
 
 


### PR DESCRIPTION
make nfd script more robust at finding the CR example
fix type in fole name