### PR TITLE
add suggested namespace

### DIFF
--- a/bundle-ocp/manifests/das-operator.clusterserviceversion.yaml
+++ b/bundle-ocp/manifests/das-operator.clusterserviceversion.yaml
@@ -33,6 +33,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: das-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.40.0

--- a/deploy/base-csv/das-operator.clusterserviceversion.yaml
+++ b/deploy/base-csv/das-operator.clusterserviceversion.yaml
@@ -15,6 +15,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: das-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     capabilities: Basic Install
     categories: Drivers and plugins


### PR DESCRIPTION
Need to add this so that "das-operator" shows up as the default namespace in OperatorHub during installing the opreator.

Implements: [OCPNODE-3541](https://issues.redhat.com//browse/OCPNODE-3541)