### PR TITLE
change imageurl for test pods to use internal copy

### DIFF
--- a/samples/test-pod.yaml
+++ b/samples/test-pod.yaml
@@ -6,7 +6,7 @@ spec:
   restartPolicy: OnFailure
   containers:
   - name: cuda-vectoradd-1
-    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8"
+    image: "quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi"
     resources:
       limits:
         nvidia.com/mig-1g.5gb: 1

--- a/samples/test-statefulset.yaml
+++ b/samples/test-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: cuda-vectoradd-1
-        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8
+        image: quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi
         resources:
           limits:
             nvidia.com/mig-1g.5gb: 1

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -29,7 +29,7 @@ func gpuSlicePodSpec(profile string, mode instav1.EmulatedMode) corev1.PodSpec {
 	image := "quay.io/prometheus/busybox"
 	command := []string{"sh", "-c", "env && sleep 3600"}
 	if mode == instav1.EmulatedModeDisabled {
-		image = "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8"
+		image = "quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi"
 		command = []string{"sh", "-c", "/cuda-samples/vectorAdd && env && sleep 3600"}
 	}
 	return corev1.PodSpec{

--- a/test/perf/load_with_stats.sh
+++ b/test/perf/load_with_stats.sh
@@ -24,7 +24,7 @@ spec:
   - name: instaslice.redhat.com/accelerator
   containers:
   - name: $ORIGINAL_NAME
-    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8"
+    image: "quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi"
     resources:
       limits:
         nvidia.com/mig-1g.5gb: 1

--- a/test/test-deployment.yaml
+++ b/test/test-deployment.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: cuda-vectoradd
-        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8
+        image: quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi
         resources:
           limits:
             nvidia.com/mig-1g.5gb: "1"

--- a/test/test-pod-multi-resource.yaml
+++ b/test/test-pod-multi-resource.yaml
@@ -6,7 +6,7 @@ spec:
   restartPolicy: OnFailure
   containers:
   - name: cuda-vectoradd-1
-    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8"  # Requires real GPUs
+    image: "quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi"  # Requires real GPUs
     resources:
       limits:
         nvidia.com/mig-1g.5gb: "2"

--- a/test/test-pod.yaml
+++ b/test/test-pod.yaml
@@ -6,7 +6,7 @@ spec:
   restartPolicy: OnFailure
   containers:
   - name: cuda-vectoradd-1
-    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8" # requires real GPUs
+    image: "quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi" # requires real GPUs
     resources:
       limits:
         nvidia.com/mig-1g.5gb: "1"


### PR DESCRIPTION
use quay.io/dasoperator/cuda-sample:vectoradd-cuda12.5.0-ubi for test pods to make tests more reliable.

Implements: [OCPNODE-3542](https://issues.redhat.com//browse/OCPNODE-3542)