### PR TITLE
OCPNODE-3547: remove infinite loop in operator reconciler update

### DIFF
--- a/bindata/assets/instaslice-operator/scheduler-authentication-reader_rbac.authorization.clusterrolebinding.yaml
+++ b/bindata/assets/instaslice-operator/scheduler-authentication-reader_rbac.authorization.clusterrolebinding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
   name: das-scheduler-authentication-reader
+  namespace: das-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/bindata/assets/instaslice-operator/scheduler-view_rbac.authorization.clusterrolebinding.yaml
+++ b/bindata/assets/instaslice-operator/scheduler-view_rbac.authorization.clusterrolebinding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
   name: das-scheduler-view
+  namespace: das-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/bindata/assets/instaslice-operator/scheduler_rbac.clusterrole.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_rbac.clusterrole.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: das-scheduler
 rules:
 - apiGroups:

--- a/bindata/assets/instaslice-operator/scheduler_rbac.clusterrolebinding.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_rbac.clusterrolebinding.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
   name: das-scheduler
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bindata/assets/instaslice-operator/scheduler_rbac.role.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_rbac.role.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: das-scheduler
+  namespace: das-operator
 rules:
 - apiGroups:
   - ""
@@ -24,3 +24,10 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/bindata/assets/instaslice-operator/scheduler_rbac.rolebinding.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_rbac.rolebinding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  creationTimestamp: null
   name: das-scheduler
+  namespace: das-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -54,13 +54,14 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	if err != nil {
 		return err
 	}
-	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 
 	namespace := cc.OperatorNamespace
 	if namespace == "openshift-config-managed" {
 		// we need to fall back to our default namespace rather than library-go's when running outside the cluster
 		namespace = operatorNamespace
 	}
+
+	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactoryWithOptions(operatorConfigClient, 10*time.Minute, operatorclientinformers.WithNamespace(namespace))
 
 	// KubeInformer for Instaslice namespace
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient, "", namespace)

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	v1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/instaslice-operator/bindata"
 	slicev1alpha1 "github.com/openshift/instaslice-operator/pkg/apis/dasoperator/v1alpha1"
@@ -49,7 +49,6 @@ type TargetConfigReconciler struct {
 	discoveryClient            discovery.DiscoveryInterface
 	dynamicClient              dynamic.Interface
 	eventRecorder              events.Recorder
-	generations                []operatorsv1.GenerationStatus
 	instasliceoperatorClient   *operatorclient.DASOperatorSetClient
 	kubeClient                 kubernetes.Interface
 	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
@@ -135,7 +134,7 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 		return fmt.Errorf("please make sure that cert-manager is installed on your cluster")
 	}
 
-	sliceOperator, err := c.operatorClient.Get(ctx, operatorclient.OperatorConfigName, metav1.GetOptions{})
+	sliceOperator, err := c.instasliceoperatorClient.Lister.DASOperators(c.namespace).Get(operatorclient.OperatorConfigName)
 	if err != nil {
 		return fmt.Errorf("unable to get operator configuration %s/%s: %w", c.namespace, operatorclient.OperatorConfigName, err)
 	}
@@ -149,19 +148,17 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 		UID:        sliceOperator.UID,
 	}
 
-	klog.V(2).InfoS("Got operator config", "emulated_mode", c.emulatedMode)
-
-	daemonset, _, err := c.manageDaemonset(ctx, ownerReference)
+	daemonset, err := c.manageDaemonset(ctx, ownerReference, sliceOperator)
 	if err != nil {
 		return err
 	}
 
-	scheduler, _, err := c.manageScheduler(ctx, ownerReference)
+	scheduler, err := c.manageScheduler(ctx, ownerReference, sliceOperator)
 	if err != nil {
 		return err
 	}
 
-	webhook, _, err := c.manageMutatingWebhookDeployment(ctx, ownerReference)
+	webhook, err := c.manageMutatingWebhookDeployment(ctx, ownerReference, sliceOperator)
 	if err != nil {
 		return err
 	}
@@ -170,7 +167,7 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 		return err
 	}
 
-	if err := c.manageMutatingWebhook(ctx, ownerReference); err != nil {
+	if err := c.manageMutatingWebhook(ctx, ownerReference, sliceOperator); err != nil {
 		return err
 	}
 	_, _, err = c.manageIssuerCR(ctx, ownerReference)
@@ -194,7 +191,7 @@ func (c *TargetConfigReconciler) sync(ctx context.Context, syncCtx factory.SyncC
 		return fmt.Errorf("failed to get das-operator deployment status: %w", err)
 	}
 
-	if err := c.updateOperatorStatus(ctx, operatorDeployment, daemonset, scheduler, webhook); err != nil {
+	if err := c.updateOperatorStatus(ctx, operatorDeployment, daemonset, scheduler, webhook, sliceOperator); err != nil {
 		return fmt.Errorf("failed to update operator status: %w", err)
 	}
 
@@ -213,7 +210,7 @@ func (c *TargetConfigReconciler) manageWebhookCertSecret() (*corev1.Secret, bool
 	return secret, true, nil
 }
 
-func (c *TargetConfigReconciler) manageMutatingWebhookDeployment(ctx context.Context, ownerReference metav1.OwnerReference) (*appsv1.Deployment, bool, error) {
+func (c *TargetConfigReconciler) manageMutatingWebhookDeployment(ctx context.Context, ownerReference metav1.OwnerReference, sliceOperator *slicev1alpha1.DASOperator) (*appsv1.Deployment, error) {
 	required := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/instaslice-operator/webhook-deployment.yaml"))
 	required.Namespace = c.namespace
 	required.OwnerReferences = []metav1.OwnerReference{
@@ -224,11 +221,17 @@ func (c *TargetConfigReconciler) manageMutatingWebhookDeployment(ctx context.Con
 			required.Spec.Template.Spec.Containers[i].Image = c.targetWebhookImage
 		}
 	}
-	err := injectCertManagerCA(required, c.namespace)
-	if err != nil {
-		return nil, false, err
+	if err := injectCertManagerCA(required, c.namespace); err != nil {
+		return nil, err
 	}
-	return resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), c.eventRecorder, required, resourcemerge.ExpectedDeploymentGeneration(required, c.generations))
+	deployment, updated, err := resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), c.eventRecorder, required, resourcemerge.ExpectedDeploymentGeneration(required, sliceOperator.Status.Generations))
+	if err != nil {
+		return nil, err
+	}
+	if updated {
+		resourcemerge.SetDeploymentGeneration(&sliceOperator.Status.Generations, deployment)
+	}
+	return deployment, nil
 }
 
 func (c *TargetConfigReconciler) manageMutatingWebhookService(ctx context.Context, ownerReference metav1.OwnerReference) error {
@@ -244,7 +247,7 @@ func (c *TargetConfigReconciler) manageMutatingWebhookService(ctx context.Contex
 	return nil
 }
 
-func (c *TargetConfigReconciler) manageMutatingWebhook(ctx context.Context, ownerReference metav1.OwnerReference) error {
+func (c *TargetConfigReconciler) manageMutatingWebhook(ctx context.Context, ownerReference metav1.OwnerReference, sliceOperator *slicev1alpha1.DASOperator) error {
 	required := resourceread.ReadMutatingWebhookConfigurationV1OrDie(bindata.MustAsset("assets/instaslice-operator/webhook.yaml"))
 	required.Namespace = c.namespace
 	required.OwnerReferences = []metav1.OwnerReference{
@@ -262,61 +265,77 @@ func (c *TargetConfigReconciler) manageMutatingWebhook(ctx context.Context, owne
 		return err
 	}
 	if updated {
-		resourcemerge.SetMutatingWebhooksConfigurationGeneration(&c.generations, mutatingWebhook)
+		resourcemerge.SetMutatingWebhooksConfigurationGeneration(&sliceOperator.Status.Generations, mutatingWebhook)
 	}
 	return nil
 }
 
-func (c *TargetConfigReconciler) manageScheduler(ctx context.Context, ownerReference metav1.OwnerReference) (*appsv1.Deployment, bool, error) {
+func (c *TargetConfigReconciler) manageScheduler(ctx context.Context, ownerReference metav1.OwnerReference, sliceOperator *slicev1alpha1.DASOperator) (*appsv1.Deployment, error) {
+	specAnnotations := make(map[string]string)
+
 	schedulerConfig := resourceread.ReadConfigMapV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_config.yaml"))
 	schedulerConfig.Namespace = c.namespace
 	schedulerConfig.OwnerReferences = []metav1.OwnerReference{
 		ownerReference,
 	}
-	_, _, err := resourceapply.ApplyConfigMap(ctx, c.kubeClient.CoreV1(), c.eventRecorder, schedulerConfig)
+	cm, _, err := resourceapply.ApplyConfigMap(ctx, c.kubeClient.CoreV1(), c.eventRecorder, schedulerConfig)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
+	specAnnotations["configmaps/"+cm.Name] = cm.GetResourceVersion()
 
 	schedulerCR := resourceread.ReadClusterRoleV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_rbac.clusterrole.yaml"))
-	schedulerCR.Namespace = c.namespace
 	schedulerCR.OwnerReferences = []metav1.OwnerReference{
 		ownerReference,
 	}
-	_, _, err = resourceapply.ApplyClusterRole(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerCR)
+	cr, _, err := resourceapply.ApplyClusterRole(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerCR)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
+	specAnnotations["clusterroles/"+cr.Name] = cr.GetResourceVersion()
 
 	schedulerCRbac := resourceread.ReadClusterRoleBindingV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_rbac.clusterrolebinding.yaml"))
-	schedulerCRbac.Namespace = c.namespace
 	schedulerCRbac.OwnerReferences = []metav1.OwnerReference{
 		ownerReference,
 	}
-	_, _, err = resourceapply.ApplyClusterRoleBinding(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerCRbac)
+	crb, _, err := resourceapply.ApplyClusterRoleBinding(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerCRbac)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
+	specAnnotations["clusterrolebindings/"+crb.Name] = crb.GetResourceVersion()
 
 	schedulerRole := resourceread.ReadRoleV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_rbac.role.yaml"))
 	schedulerRole.Namespace = c.namespace
 	schedulerRole.OwnerReferences = []metav1.OwnerReference{
 		ownerReference,
 	}
-	_, _, err = resourceapply.ApplyRole(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerRole)
+	role, _, err := resourceapply.ApplyRole(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerRole)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
+	specAnnotations["roles/"+role.Name] = role.GetResourceVersion()
+
+	schedulerRoleBinding := resourceread.ReadRoleBindingV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_rbac.rolebinding.yaml"))
+	schedulerRoleBinding.Namespace = c.namespace
+	schedulerRoleBinding.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	roleBinding, _, err := resourceapply.ApplyRoleBinding(ctx, c.kubeClient.RbacV1(), c.eventRecorder, schedulerRoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	specAnnotations["rolebindings/"+roleBinding.Name] = roleBinding.GetResourceVersion()
 
 	schedulerSA := resourceread.ReadServiceAccountV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_serviceaccount.yaml"))
 	schedulerSA.Namespace = c.namespace
 	schedulerSA.OwnerReferences = []metav1.OwnerReference{
 		ownerReference,
 	}
-	_, _, err = resourceapply.ApplyServiceAccount(ctx, c.kubeClient.CoreV1(), c.eventRecorder, schedulerSA)
+	sa, _, err := resourceapply.ApplyServiceAccount(ctx, c.kubeClient.CoreV1(), c.eventRecorder, schedulerSA)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
+	specAnnotations["serviceaccounts/"+sa.Name] = sa.GetResourceVersion()
 
 	scheduler := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/instaslice-operator/scheduler_deployment.yaml"))
 	scheduler.Namespace = c.namespace
@@ -328,10 +347,19 @@ func (c *TargetConfigReconciler) manageScheduler(ctx context.Context, ownerRefer
 			scheduler.Spec.Template.Spec.Containers[i].Image = c.targetSchedulerImage
 		}
 	}
-	return resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), c.eventRecorder, scheduler, resourcemerge.ExpectedDeploymentGeneration(scheduler, c.generations))
+	resourcemerge.MergeMap(ptr.To(false), &scheduler.Spec.Template.Annotations, specAnnotations)
+	deployment, updated, err := resourceapply.ApplyDeployment(ctx, c.kubeClient.AppsV1(), c.eventRecorder, scheduler, resourcemerge.ExpectedDeploymentGeneration(scheduler, sliceOperator.Status.Generations))
+	if err != nil {
+		return nil, err
+	}
+	if updated {
+		resourcemerge.SetDeploymentGeneration(&sliceOperator.Status.Generations, deployment)
+	}
+
+	return deployment, nil
 }
 
-func (c *TargetConfigReconciler) manageDaemonset(ctx context.Context, ownerReference metav1.OwnerReference) (*appsv1.DaemonSet, bool, error) {
+func (c *TargetConfigReconciler) manageDaemonset(ctx context.Context, ownerReference metav1.OwnerReference, sliceOperator *slicev1alpha1.DASOperator) (*appsv1.DaemonSet, error) {
 	required := resourceread.ReadDaemonSetV1OrDie(bindata.MustAsset("assets/instaslice-operator/daemonset.yaml"))
 	required.Namespace = c.namespace
 	required.OwnerReferences = []metav1.OwnerReference{
@@ -355,11 +383,18 @@ func (c *TargetConfigReconciler) manageDaemonset(ctx context.Context, ownerRefer
 			})
 		}
 	}
-	return resourceapply.ApplyDaemonSet(ctx,
+	daemonset, updated, err := resourceapply.ApplyDaemonSet(ctx,
 		c.appsClient,
 		c.eventRecorder,
 		required,
-		resourcemerge.ExpectedDaemonSetGeneration(required, c.generations))
+		resourcemerge.ExpectedDaemonSetGeneration(required, sliceOperator.Status.Generations))
+	if err != nil {
+		return nil, err
+	}
+	if updated {
+		resourcemerge.SetDaemonSetGeneration(&sliceOperator.Status.Generations, daemonset)
+	}
+	return daemonset, nil
 }
 
 func (c *TargetConfigReconciler) manageIssuerCR(ctx context.Context, ownerReference metav1.OwnerReference) (*unstructured.Unstructured, bool, error) {
@@ -434,7 +469,7 @@ func isResourceRegistered(discoveryClient discovery.DiscoveryInterface, gvk sche
 }
 
 // updateOperatorStatus calculates and updates the DAS operator status based on component health.
-func (c *TargetConfigReconciler) updateOperatorStatus(ctx context.Context, operatorDeployment *appsv1.Deployment, daemonset *appsv1.DaemonSet, scheduler *appsv1.Deployment, webhook *appsv1.Deployment) error {
+func (c *TargetConfigReconciler) updateOperatorStatus(ctx context.Context, operatorDeployment *appsv1.Deployment, daemonset *appsv1.DaemonSet, scheduler *appsv1.Deployment, webhook *appsv1.Deployment, sliceOperator *slicev1alpha1.DASOperator) error {
 	operatorReadyReplicas := operatorDeployment.Status.ReadyReplicas
 
 	// Check component health for conditions
@@ -466,6 +501,7 @@ func (c *TargetConfigReconciler) updateOperatorStatus(ctx context.Context, opera
 	_, _, err := v1helpers.UpdateStatus(ctx, c.instasliceoperatorClient, func(status *operatorsv1.OperatorStatus) error {
 		status.ReadyReplicas = operatorReadyReplicas
 		status.Conditions = conditions
+		status.Generations = sliceOperator.Status.Generations
 		return nil
 	})
 


### PR DESCRIPTION
This PR tracks the generation number and resource versions of various components for the scheduler. There is also a small patch for scheduler RBACs to fix the events.