### PR TITLE
Add missing RBAC for the persist volumes for the scheduler

### DIFF
--- a/bindata/assets/instaslice-operator/scheduler_rbac.clusterrole.yaml
+++ b/bindata/assets/instaslice-operator/scheduler_rbac.clusterrole.yaml
@@ -47,6 +47,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 - apiGroups:
   - config.openshift.io
   resources:


### PR DESCRIPTION
While testing https://github.com/openshift/instaslice-operator/blob/next/samples/vllm_job.yaml, the scheduler pod would complain about the missing persistent volume related RBAC. With the changes in this PR, the vllm job example runs fine. 

```bash
$ curl -X POST http://localhost:8000/v1/completions     -H "Content-Type: application/json"     -d '{"model": "facebook/opt-125m", "prompt": "The coolest city in US is", "max_tokens": 100}' | jq '.'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   761  100   673  100    88   1700    222 --:--:-- --:--:-- --:--:--  1921
{
  "id": "cmpl-9249cb5b49e847c48d895c841f727596",
  "object": "text_completion",
  "created": 10299,
  "model": "facebook/opt-125m",
  "choices": [
    {
      "index": 0,
      "text": " New Orleans, Louisiana.  We have the biggest population centers in the world.\nMy hometown is pretty spread out from my state, even if they have a population of about 70% it's still pretty spread out a massive amount. We've have the biggest apartment crowd in the US though, so it's nice to go out to find a good place to throw an event. MoBo is a terrible place but bs.\nI hear ya.  In my state, NY, having a",
      "logprobs": null,
      "finish_reason": "length"
    }
  ],
  "usage": {
    "prompt_tokens": 7,
    "total_tokens": 107,
    "completion_tokens": 100
  }
}
```