### PR TITLE
OCPBUGS-60686: set CUDA_VISIBLE_DEVICES to device index instead of UUID

### DIFF
--- a/pkg/daemonset/deviceplugins/server.go
+++ b/pkg/daemonset/deviceplugins/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -564,7 +565,8 @@ func BuildCDIDevices(kind, sanitizedClass, id string, annotations map[string]str
 		env = []string{envVar}
 		if eq := strings.Index(envVar, "="); eq != -1 {
 			val := envVar[eq+1:]
-			env = append(env, fmt.Sprintf("CUDA_VISIBLE_DEVICES=%s", val))
+			cudaVal := convertUUIDsToIndices(val)
+			env = append(env, fmt.Sprintf("CUDA_VISIBLE_DEVICES=%s", cudaVal))
 		}
 	}
 	specObj := &cdispec.Spec{
@@ -640,6 +642,23 @@ func WriteCDISpecForResource(resourceName string, id string, annotations map[str
 	klog.InfoS("wrote CDI spec", "name", specName)
 
 	return specPath, cdiDevices, nil
+}
+
+// convertUUIDsToIndices converts a comma-separated list of UUIDs to indexed values
+// e.g., "uuid1,uuid2,uuid3" becomes "0,1,2"
+func convertUUIDsToIndices(uuidList string) string {
+	if uuidList == "" {
+		return ""
+	}
+
+	uuids := strings.Split(uuidList, ",")
+	indices := make([]string, len(uuids))
+
+	for i := range uuids {
+		indices[i] = strconv.Itoa(i)
+	}
+
+	return strings.Join(indices, ",")
 }
 
 // writeCDISpecForResource is kept for backwards compatibility with older code.

--- a/pkg/daemonset/deviceplugins/server_test.go
+++ b/pkg/daemonset/deviceplugins/server_test.go
@@ -330,6 +330,27 @@ func TestGetAllocationsByNodeGPU(t *testing.T) {
 	}
 }
 
+func TestConvertUUIDsToIndices(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"uuid1", "0"},
+		{"uuid1,uuid2", "0,1"},
+		{"uuid1,uuid2,uuid3", "0,1,2"},
+		{"GPU-12345678-1234-5678-abcd-123456789012", "0"},
+		{"GPU-12345678-1234-5678-abcd-123456789012,GPU-87654321-4321-8765-dcba-210987654321", "0,1"},
+	}
+
+	for _, test := range tests {
+		result := convertUUIDsToIndices(test.input)
+		if result != test.expected {
+			t.Errorf("convertUUIDsToIndices(%q) = %q, expected %q", test.input, result, test.expected)
+		}
+	}
+}
+
 func TestWriteCDISpecForResourceEnv(t *testing.T) {
 	dir := t.TempDir()
 	if err := cdi.Configure(cdi.WithSpecDirs(dir), cdi.WithAutoRefresh(false)); err != nil {
@@ -353,7 +374,35 @@ func TestWriteCDISpecForResourceEnv(t *testing.T) {
 	if len(env) != 2 {
 		t.Fatalf("unexpected env %v", env)
 	}
-	if env[0] != "NVIDIA_VISIBLE_DEVICES=foo" || env[1] != "CUDA_VISIBLE_DEVICES=foo" {
+	if env[0] != "NVIDIA_VISIBLE_DEVICES=foo" || env[1] != "CUDA_VISIBLE_DEVICES=0" {
+		t.Fatalf("unexpected env %v", env)
+	}
+}
+
+func TestWriteCDISpecForResourceEnvMultipleUUIDs(t *testing.T) {
+	dir := t.TempDir()
+	if err := cdi.Configure(cdi.WithSpecDirs(dir), cdi.WithAutoRefresh(false)); err != nil {
+		t.Fatalf("failed to configure cdi: %v", err)
+	}
+
+	path, _, err := WriteCDISpecForResource("vendor/class", "id-env-multi", nil, "NVIDIA_VISIBLE_DEVICES=uuid1,uuid2,uuid3")
+	if err != nil {
+		t.Fatalf("failed to write spec: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read spec: %v", err)
+	}
+	var spec cdispec.Spec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("failed to unmarshal spec: %v", err)
+	}
+	env := spec.Devices[0].ContainerEdits.Env
+	if len(env) != 2 {
+		t.Fatalf("unexpected env %v", env)
+	}
+	if env[0] != "NVIDIA_VISIBLE_DEVICES=uuid1,uuid2,uuid3" || env[1] != "CUDA_VISIBLE_DEVICES=0,1,2" {
 		t.Fatalf("unexpected env %v", env)
 	}
 }

--- a/samples/vllm_gpt_oss_20b.yaml
+++ b/samples/vllm_gpt_oss_20b.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: huggingface-secret
+type: Opaque
+data:
+  HF_TOKEN: <base64 of your hugging face token>
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: huggingface-cache-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vllm-gpt-oss-20b
+  labels:
+    app: vllm-gpt-oss-20b
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: vllm
+    image: vllm/vllm-openai:latest
+    ports:
+    - containerPort: 8000
+    env:
+    - name: HUGGING_FACE_HUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: huggingface-secret
+          key: HF_TOKEN
+    command: ["/bin/bash"]
+    args:
+    - -c
+    - |
+      # Install latest Transformers from source to support gpt_oss model type
+      pip install git+https://github.com/huggingface/transformers.git
+
+      # Start vLLM server with GPT-OSS model
+      # GPU memory utilization reduced to 0.6 to fit in 40GB MIG slice
+      # Using explicit --port argument to avoid Kubernetes service discovery conflicts
+      vllm serve openai/gpt-oss-20b --host 0.0.0.0 --port 8000 --max-model-len 2048 --gpu-memory-utilization 0.6
+    resources:
+      limits:
+        nvidia.com/mig-7g.40gb: 1
+      requests:
+        memory: "8Gi"
+        cpu: "2"
+    volumeMounts:
+    - name: cache-volume
+      mountPath: /root/.cache/huggingface
+  volumes:
+  - name: cache-volume
+    persistentVolumeClaim:
+      claimName: huggingface-cache-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-gpt-oss-20b-service
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8000
+    targetPort: 8000
+    name: http
+  selector:
+    app: vllm-gpt-oss-20b

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -633,12 +634,29 @@ func verifyVisibleDevicesEnv(ctx context.Context, namespace, podName string, exp
 		}
 	}
 
-	if nvidia == "" || cuda == "" || nvidia != cuda {
+	if nvidia == "" || cuda == "" {
 		return false, nil
 	}
 
+	// CUDA_VISIBLE_DEVICES should be indexed values (0,1,2...) while NVIDIA_VISIBLE_DEVICES contains UUIDs
+	nvidiaDevices := strings.Split(strings.TrimSpace(nvidia), ",")
+	cudaDevices := strings.Split(strings.TrimSpace(cuda), ",")
+
+	// Both should have the same number of devices
+	if len(nvidiaDevices) != len(cudaDevices) {
+		return false, nil
+	}
+
+	// CUDA_VISIBLE_DEVICES should contain indexed values (0, 1, 2, ...)
+	for i, cudaDevice := range cudaDevices {
+		expectedIndex := strconv.Itoa(i)
+		if strings.TrimSpace(cudaDevice) != expectedIndex {
+			return false, nil
+		}
+	}
+
 	if expectedCount > 0 {
-		if len(strings.Split(strings.TrimSpace(nvidia), ",")) != expectedCount {
+		if len(nvidiaDevices) != expectedCount {
 			return false, nil
 		}
 	}
@@ -746,6 +764,231 @@ var _ = Describe("MIG placement start index", Ordered, func() {
 	})
 })
 
+var _ = Describe("MIG UUID verification", Ordered, func() {
+	var (
+		namespace string
+		podName   string
+	)
+
+	BeforeAll(func() {
+		if os.Getenv("KUBECONFIG") == "" {
+			Skip("KUBECONFIG is not set; skipping e2e test")
+		}
+	})
+
+	BeforeAll(func() {
+		namespace = "das-e2e-mig-uuid"
+		podName = "mig-uuid-test-pod"
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		By("creating namespace " + namespace)
+		_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+			},
+			Spec: migUuidPodSpec(),
+		}
+
+		By("creating MIG UUID test pod")
+		Expect(createPods(context.Background(), namespace, []*corev1.Pod{pod})).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("deleting namespace " + namespace)
+		err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, 2*time.Minute, time.Second).Should(BeTrue())
+	})
+
+	It("should be running", func(ctx SpecContext) {
+		Eventually(func() (corev1.PodPhase, error) {
+			p, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			return p.Status.Phase, nil
+		}, 60*time.Minute, 5*time.Second).Should(Equal(corev1.PodRunning))
+	})
+
+	It("should have NVIDIA_VISIBLE_DEVICES matching MIG_SLICE_UUID", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyMigUuidMatches(ctx, namespace, podName)
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+
+	It("should successfully run vector addition", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyVectorAddSuccess(ctx, namespace, podName, "")
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+})
+
+var _ = Describe("MIG UUID dual slice verification", Ordered, func() {
+	var (
+		namespace string
+		podName   string
+	)
+
+	BeforeAll(func() {
+		if os.Getenv("KUBECONFIG") == "" {
+			Skip("KUBECONFIG is not set; skipping e2e test")
+		}
+	})
+
+	BeforeAll(func() {
+		namespace = "das-e2e-mig-uuid-dual"
+		podName = "mig-uuid-dual-test-pod"
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		By("creating namespace " + namespace)
+		_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+			},
+			Spec: migUuidDualPodSpec(),
+		}
+
+		By("creating MIG UUID dual slice test pod")
+		Expect(createPods(context.Background(), namespace, []*corev1.Pod{pod})).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("deleting namespace " + namespace)
+		err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, 2*time.Minute, time.Second).Should(BeTrue())
+	})
+
+	It("should be running", func(ctx SpecContext) {
+		Eventually(func() (corev1.PodPhase, error) {
+			p, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			return p.Status.Phase, nil
+		}, 60*time.Minute, 5*time.Second).Should(Equal(corev1.PodRunning))
+	})
+
+	It("should report 2 CUDA devices", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyDualSliceCudaDeviceCount(ctx, namespace, podName)
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+
+	It("should have NVIDIA_VISIBLE_DEVICES matching MIG device UUIDs", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyDualSliceMigUuidMatches(ctx, namespace, podName)
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+
+	It("should successfully run vector addition on both devices", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyDualSliceVectorAddSuccess(ctx, namespace, podName)
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+})
+
+var _ = Describe("MIG UUID multi-container verification", Ordered, func() {
+	var (
+		namespace string
+		podName   string
+	)
+
+	BeforeAll(func() {
+		if os.Getenv("KUBECONFIG") == "" {
+			Skip("KUBECONFIG is not set; skipping e2e test")
+		}
+	})
+
+	BeforeAll(func() {
+		namespace = "das-e2e-mig-uuid-multicontainer"
+		podName = "mig-uuid-multicontainer-test-pod"
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		By("creating namespace " + namespace)
+		_, err := kubeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+			},
+			Spec: migUuidMulticontainerPodSpec(),
+		}
+
+		By("creating MIG UUID multi-container test pod")
+		Expect(createPods(context.Background(), namespace, []*corev1.Pod{pod})).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("deleting namespace " + namespace)
+		err := kubeClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+			return apierrors.IsNotFound(err)
+		}, 2*time.Minute, time.Second).Should(BeTrue())
+	})
+
+	It("should be running", func(ctx SpecContext) {
+		Eventually(func() (corev1.PodPhase, error) {
+			p, err := kubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+			return p.Status.Phase, nil
+		}, 60*time.Minute, 5*time.Second).Should(Equal(corev1.PodRunning))
+	})
+
+	It("should have NVIDIA_VISIBLE_DEVICES matching MIG_SLICE_UUID in gpu-a container", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyMulticontainerMigUuidMatches(ctx, namespace, podName, "gpu-a")
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+
+	It("should have NVIDIA_VISIBLE_DEVICES matching MIG_SLICE_UUID in gpu-b container", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyMulticontainerMigUuidMatches(ctx, namespace, podName, "gpu-b")
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+
+	It("should successfully run vector addition in gpu-a container", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyVectorAddSuccess(ctx, namespace, podName, "gpu-a")
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+
+	It("should successfully run vector addition in gpu-b container", func(ctx SpecContext) {
+		Eventually(func() (bool, error) {
+			return verifyVectorAddSuccess(ctx, namespace, podName, "gpu-b")
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+	})
+})
+
 var _ = Describe("Operator status", Ordered, func() {
 	BeforeAll(func() {
 		if os.Getenv("KUBECONFIG") == "" {
@@ -797,6 +1040,146 @@ var _ = Describe("Operator status", Ordered, func() {
 		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 })
+
+func verifyMigUuidMatches(ctx context.Context, namespace, podName string) (bool, error) {
+	req := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return false, err
+	}
+
+	var nvidia, migUuid string
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "NVIDIA_VISIBLE_DEVICES=") {
+			nvidia = strings.TrimPrefix(line, "NVIDIA_VISIBLE_DEVICES=")
+		}
+		if strings.HasPrefix(line, "MIG_SLICE_UUID=") {
+			migUuid = strings.TrimPrefix(line, "MIG_SLICE_UUID=")
+		}
+	}
+
+	if nvidia == "" || migUuid == "" {
+		return false, nil
+	}
+
+	// NVIDIA_VISIBLE_DEVICES should match the MIG_SLICE_UUID
+	return strings.TrimSpace(nvidia) == strings.TrimSpace(migUuid), nil
+}
+
+func verifyDualSliceCudaDeviceCount(ctx context.Context, namespace, podName string) (bool, error) {
+	req := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return false, err
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "CUDA_DEVICE_COUNT=") {
+			countStr := strings.TrimPrefix(line, "CUDA_DEVICE_COUNT=")
+			count := strings.TrimSpace(countStr)
+			return count == "2", nil
+		}
+	}
+	return false, nil
+}
+
+func verifyDualSliceMigUuidMatches(ctx context.Context, namespace, podName string) (bool, error) {
+	req := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return false, err
+	}
+
+	var nvidia string
+	var migDevice0UUID, migDevice1UUID string
+
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "NVIDIA_VISIBLE_DEVICES=") {
+			nvidia = strings.TrimPrefix(line, "NVIDIA_VISIBLE_DEVICES=")
+		}
+		if strings.HasPrefix(line, "MIG_DEVICE_0_UUID=") {
+			migDevice0UUID = strings.TrimPrefix(line, "MIG_DEVICE_0_UUID=")
+		}
+		if strings.HasPrefix(line, "MIG_DEVICE_1_UUID=") {
+			migDevice1UUID = strings.TrimPrefix(line, "MIG_DEVICE_1_UUID=")
+		}
+	}
+
+	if nvidia == "" || migDevice0UUID == "" || migDevice1UUID == "" {
+		return false, nil
+	}
+
+	// NVIDIA_VISIBLE_DEVICES should contain both MIG device UUIDs, comma-separated
+	nvidiaDevices := strings.Split(strings.TrimSpace(nvidia), ",")
+	if len(nvidiaDevices) != 2 {
+		return false, nil
+	}
+
+	// Check that both UUIDs are present in NVIDIA_VISIBLE_DEVICES
+	foundDevice0 := false
+	foundDevice1 := false
+	for _, device := range nvidiaDevices {
+		trimmedDevice := strings.TrimSpace(device)
+		if trimmedDevice == strings.TrimSpace(migDevice0UUID) {
+			foundDevice0 = true
+		}
+		if trimmedDevice == strings.TrimSpace(migDevice1UUID) {
+			foundDevice1 = true
+		}
+	}
+
+	return foundDevice0 && foundDevice1, nil
+}
+
+func verifyDualSliceVectorAddSuccess(ctx context.Context, namespace, podName string) (bool, error) {
+	req := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return false, err
+	}
+
+	// Check that both devices (0 and 1) have successful vector addition
+	dev0Success := false
+	dev1Success := false
+
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "VECTOR_ADD_STATUS_DEV_0=") {
+			status := strings.TrimPrefix(line, "VECTOR_ADD_STATUS_DEV_0=")
+			dev0Success = strings.TrimSpace(status) == "OK"
+		}
+		if strings.HasPrefix(line, "VECTOR_ADD_STATUS_DEV_1=") {
+			status := strings.TrimPrefix(line, "VECTOR_ADD_STATUS_DEV_1=")
+			dev1Success = strings.TrimSpace(status) == "OK"
+		}
+	}
+
+	return dev0Success && dev1Success, nil
+}
+
+func verifyMulticontainerMigUuidMatches(ctx context.Context, namespace, podName, containerName string) (bool, error) {
+	req := kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Container: containerName})
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return false, err
+	}
+
+	var nvidia, migUuid string
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "NVIDIA_VISIBLE_DEVICES=") {
+			nvidia = strings.TrimPrefix(line, "NVIDIA_VISIBLE_DEVICES=")
+		}
+		if strings.HasPrefix(line, "MIG_SLICE_UUID=") {
+			migUuid = strings.TrimPrefix(line, "MIG_SLICE_UUID=")
+		}
+	}
+
+	if nvidia == "" || migUuid == "" {
+		return false, nil
+	}
+
+	// NVIDIA_VISIBLE_DEVICES should match the MIG_SLICE_UUID for each container
+	return strings.TrimSpace(nvidia) == strings.TrimSpace(migUuid), nil
+}
 
 // findCondition finds a condition in a list of conditions by type.
 func findCondition(conditions []operatorv1.OperatorCondition, conditionType string) *operatorv1.OperatorCondition {

--- a/test/e2e/mig_uuid_helpers.go
+++ b/test/e2e/mig_uuid_helpers.go
@@ -1,0 +1,514 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+)
+
+func migUuidPodSpec() corev1.PodSpec {
+	image := "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+	command := []string{"sh", "-c"}
+	args := []string{`
+echo "=== MIG UUID Verification Test (Pod: $HOSTNAME) ==="
+echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+
+cat > /tmp/print_mig_uuid.cu << 'EOF'
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N) C[i] = A[i] + B[i];
+}
+
+int main() {
+    int dev = 0;
+    cudaSetDevice(dev);
+    CUresult cr = cuInit(0);
+    if (cr != CUDA_SUCCESS) {
+        printf("ERROR: cuInit failed: %d\n", (int)cr);
+        return 1;
+    }
+    CUdevice cudev;
+    cr = cuDeviceGet(&cudev, dev);
+    if (cr != CUDA_SUCCESS) {
+        printf("ERROR: cuDeviceGet failed: %d\n", (int)cr);
+        return 1;
+    }
+    CUuuid u2;
+    cr = cuDeviceGetUuid_v2(&u2, cudev);
+    if (cr != CUDA_SUCCESS) {
+        printf("ERROR: cuDeviceGetUuid_v2 failed: %d\n", (int)cr);
+        return 1;
+    }
+    printf("MIG_SLICE_UUID=MIG-");
+    for (int i = 0; i < 16; i++) {
+        printf("%02x", (unsigned char)u2.bytes[i]);
+        if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+    }
+    printf("\n");
+    
+    char* nvidia_visible = getenv("NVIDIA_VISIBLE_DEVICES");
+    char* cuda_visible = getenv("CUDA_VISIBLE_DEVICES");
+    printf("NVIDIA_VISIBLE_DEVICES=%s\n", nvidia_visible ? nvidia_visible : "NOT_SET");
+    printf("CUDA_VISIBLE_DEVICES=%s\n", cuda_visible ? cuda_visible : "NOT_SET");
+    printf("POD_HOSTNAME=%s\n", getenv("HOSTNAME"));
+    
+    const int N = 1 << 16;
+    const size_t size = N * sizeof(float);
+    float *h_A = (float*)malloc(size);
+    float *h_B = (float*)malloc(size);
+    float *h_C = (float*)malloc(size);
+    if (!h_A || !h_B || !h_C) {
+        printf("ERROR: Host allocation failed\n");
+        return 1;
+    }
+    for (int i = 0; i < N; ++i) { h_A[i] = 1.0f; h_B[i] = 2.0f; }
+    
+    float *d_A = nullptr, *d_B = nullptr, *d_C = nullptr;
+    if (cudaMalloc(&d_A, size) != cudaSuccess ||
+        cudaMalloc(&d_B, size) != cudaSuccess ||
+        cudaMalloc(&d_C, size) != cudaSuccess) {
+        printf("ERROR: Device allocation failed\n");
+        return 1;
+    }
+    cudaError_t err;
+    err = cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) { printf("ERROR: memcpy H2D A: %s\n", cudaGetErrorString(err)); return 1; }
+    err = cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) { printf("ERROR: memcpy H2D B: %s\n", cudaGetErrorString(err)); return 1; }
+    int threads = 256; int blocks = (N + threads - 1) / threads;
+    vecAdd<<<blocks, threads>>>(d_A, d_B, d_C, N);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("ERROR: Kernel launch failed: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    err = cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+    if (err != cudaSuccess) { printf("ERROR: memcpy D2H C: %s\n", cudaGetErrorString(err)); return 1; }
+    bool ok = true;
+    for (int i = 0; i < 10; ++i) {
+        if (h_C[i] != 3.0f) { ok = false; break; }
+    }
+    printf("VECTOR_ADD_STATUS=%s\n", ok ? "OK" : "FAIL");
+    
+    cudaFree(d_A); cudaFree(d_B); cudaFree(d_C);
+    free(h_A); free(h_B); free(h_C);
+    return 0;
+}
+EOF
+
+nvcc -o /tmp/print_mig_uuid /tmp/print_mig_uuid.cu -lcuda
+/tmp/print_mig_uuid
+
+while true; do
+  echo "Pod $HOSTNAME is running with MIG slice access..."
+  sleep 300
+done
+`}
+
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:    "mig-uuid-printer",
+				Image:   image,
+				Command: command,
+				Args:    args,
+				Env: []corev1.EnvVar{
+					{
+						Name: "NODE_NAME",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "spec.nodeName",
+							},
+						},
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("1"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr.To(false),
+					Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				},
+			},
+		},
+	}
+}
+
+func migUuidDualPodSpec() corev1.PodSpec {
+	image := "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+	command := []string{"sh", "-c"}
+	args := []string{`
+echo "=== MIG UUID Dual-Slice Test (Pod: $HOSTNAME) ==="
+echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+
+cat > /tmp/print_all_mig_uuid.cu << 'EOF'
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N) C[i] = A[i] + B[i];
+}
+
+static void print_uuid(const unsigned char bytes[16]) {
+    for (int i = 0; i < 16; i++) {
+        printf("%02x", bytes[i]);
+        if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+    }
+}
+
+int main() {
+    int count = 0;
+    cudaError_t cerr = cudaGetDeviceCount(&count);
+    if (cerr != cudaSuccess) {
+        printf("ERROR: cudaGetDeviceCount failed: %s\n", cudaGetErrorString(cerr));
+        return 1;
+    }
+    printf("CUDA_DEVICE_COUNT=%d\n", count);
+
+    CUresult cr = cuInit(0);
+    if (cr != CUDA_SUCCESS) {
+        printf("ERROR: cuInit failed: %d\n", (int)cr);
+        return 1;
+    }
+
+    for (int dev = 0; dev < count; ++dev) {
+        cudaSetDevice(dev);
+        CUdevice cudev;
+        cr = cuDeviceGet(&cudev, dev);
+        if (cr != CUDA_SUCCESS) {
+            printf("ERROR: cuDeviceGet(%d) failed: %d\n", dev, (int)cr);
+            continue;
+        }
+        CUuuid uuid;
+        cr = cuDeviceGetUuid_v2(&uuid, cudev);
+        if (cr != CUDA_SUCCESS) {
+            printf("ERROR: cuDeviceGetUuid_v2(%d) failed: %d\n", dev, (int)cr);
+            continue;
+        }
+        printf("MIG_DEVICE_%d_UUID=MIG-", dev);
+        print_uuid((const unsigned char*)uuid.bytes);
+        printf("\n");
+
+        const int N = 1 << 16;
+        const size_t size = N * sizeof(float);
+        float *h_A = (float*)malloc(size);
+        float *h_B = (float*)malloc(size);
+        float *h_C = (float*)malloc(size);
+        if (!h_A || !h_B || !h_C) {
+            printf("ERROR: Host allocation failed on device %d\n", dev);
+            return 1;
+        }
+        for (int i = 0; i < N; ++i) { h_A[i] = 1.0f; h_B[i] = 2.0f; }
+        float *d_A = nullptr, *d_B = nullptr, *d_C = nullptr;
+        if (cudaMalloc(&d_A, size) != cudaSuccess ||
+            cudaMalloc(&d_B, size) != cudaSuccess ||
+            cudaMalloc(&d_C, size) != cudaSuccess) {
+            printf("ERROR: Device allocation failed on device %d\n", dev);
+            return 1;
+        }
+        cerr = cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+        if (cerr != cudaSuccess) { printf("ERROR: memcpy H2D A on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+        cerr = cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+        if (cerr != cudaSuccess) { printf("ERROR: memcpy H2D B on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+        int threads = 256; int blocks = (N + threads - 1) / threads;
+        vecAdd<<<blocks, threads>>>(d_A, d_B, d_C, N);
+        cerr = cudaGetLastError();
+        if (cerr != cudaSuccess) { printf("ERROR: Kernel launch on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+        cerr = cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+        if (cerr != cudaSuccess) { printf("ERROR: memcpy D2H C on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+        bool ok = true; for (int i = 0; i < 10; ++i) { if (h_C[i] != 3.0f) { ok = false; break; } }
+        printf("VECTOR_ADD_STATUS_DEV_%d=%s\n", dev, ok ? "OK" : "FAIL");
+        cudaFree(d_A); cudaFree(d_B); cudaFree(d_C);
+        free(h_A); free(h_B); free(h_C);
+    }
+
+    const char* nvv = getenv("NVIDIA_VISIBLE_DEVICES");
+    const char* cvv = getenv("CUDA_VISIBLE_DEVICES");
+    printf("NVIDIA_VISIBLE_DEVICES=%s\n", nvv ? nvv : "NOT_SET");
+    printf("CUDA_VISIBLE_DEVICES=%s\n", cvv ? cvv : "NOT_SET");
+    printf("POD_HOSTNAME=%s\n", getenv("HOSTNAME"));
+    return 0;
+}
+EOF
+
+nvcc -o /tmp/print_all_mig_uuid /tmp/print_all_mig_uuid.cu -lcuda
+/tmp/print_all_mig_uuid
+
+while true; do
+  echo "Pod $HOSTNAME is running with two MIG slices..."
+  sleep 300
+done
+`}
+
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:    "mig-uuid-printer",
+				Image:   image,
+				Command: command,
+				Args:    args,
+				Env: []corev1.EnvVar{
+					{
+						Name: "NODE_NAME",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "spec.nodeName",
+							},
+						},
+					},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("2"),
+					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: ptr.To(false),
+					Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				},
+			},
+		},
+	}
+}
+
+func migUuidMulticontainerPodSpec() corev1.PodSpec {
+	containerA := corev1.Container{
+		Name:  "gpu-a",
+		Image: "nvidia/cuda:12.4.1-devel-ubuntu22.04",
+		Command: []string{"sh", "-c"},
+		Args: []string{`
+echo "=== Multi-Container MIG Test (Container: gpu-a, Pod: $HOSTNAME) ==="
+echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+
+cat > /tmp/print_mig_uuid.cu << 'EOF'
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N) C[i] = A[i] + B[i];
+}
+
+static void print_uuid(const unsigned char bytes[16]) {
+    for (int i = 0; i < 16; i++) {
+        printf("%02x", bytes[i]);
+        if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+    }
+}
+
+int main() {
+    int count = 0;
+    cudaError_t cerr = cudaGetDeviceCount(&count);
+    if (cerr != cudaSuccess) { printf("ERROR: cudaGetDeviceCount: %s\n", cudaGetErrorString(cerr)); return 1; }
+    printf("CUDA_DEVICE_COUNT=%d\n", count);
+
+    int dev = 0;
+    cudaSetDevice(dev);
+
+    CUresult cr = cuInit(0);
+    if (cr != CUDA_SUCCESS) { printf("ERROR: cuInit: %d\n", (int)cr); return 1; }
+    CUdevice cudev; cr = cuDeviceGet(&cudev, dev);
+    if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGet: %d\n", (int)cr); return 1; }
+    CUuuid uuid; cr = cuDeviceGetUuid_v2(&uuid, cudev);
+    if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGetUuid_v2: %d\n", (int)cr); return 1; }
+    printf("MIG_SLICE_UUID=MIG-"); print_uuid((const unsigned char*)uuid.bytes); printf("\n");
+
+    const int N = 1 << 16; const size_t sz = N * sizeof(float);
+    float *hA=(float*)malloc(sz), *hB=(float*)malloc(sz), *hC=(float*)malloc(sz);
+    for (int i=0;i<N;++i){hA[i]=1.0f;hB[i]=2.0f;}
+    float *dA=nullptr,*dB=nullptr,*dC=nullptr;
+    if (cudaMalloc(&dA,sz)!=cudaSuccess||cudaMalloc(&dB,sz)!=cudaSuccess||cudaMalloc(&dC,sz)!=cudaSuccess){printf("ERROR: cudaMalloc\n");return 1;}
+    cudaMemcpy(dA,hA,sz,cudaMemcpyHostToDevice); cudaMemcpy(dB,hB,sz,cudaMemcpyHostToDevice);
+    int threads=256, blocks=(N+threads-1)/threads; vecAdd<<<blocks,threads>>>(dA,dB,dC,N);
+    cerr = cudaGetLastError(); if (cerr!=cudaSuccess){printf("ERROR: kernel: %s\n", cudaGetErrorString(cerr)); return 1;}
+    cudaMemcpy(hC,dC,sz,cudaMemcpyDeviceToHost);
+    bool ok=true; for(int i=0;i<10;++i){ if(hC[i]!=3.0f){ok=false;break;} }
+    printf("VECTOR_ADD_STATUS=%s\n", ok?"OK":"FAIL");
+    cudaFree(dA); cudaFree(dB); cudaFree(dC); free(hA); free(hB); free(hC);
+    return 0;
+}
+EOF
+
+nvcc -o /tmp/print_mig_uuid /tmp/print_mig_uuid.cu -lcuda
+/tmp/print_mig_uuid
+
+while true; do echo "gpu-a running..."; sleep 300; done
+`},
+		Env: []corev1.EnvVar{
+			{
+				Name: "NODE_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.nodeName",
+					},
+				},
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("1"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+	}
+
+	containerB := corev1.Container{
+		Name:  "gpu-b",
+		Image: "nvidia/cuda:12.4.1-devel-ubuntu22.04",
+		Command: []string{"sh", "-c"},
+		Args: []string{`
+echo "=== Multi-Container MIG Test (Container: gpu-b, Pod: $HOSTNAME) ==="
+echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+
+cat > /tmp/print_mig_uuid.cu << 'EOF'
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+__global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N) C[i] = A[i] + B[i];
+}
+
+static void print_uuid(const unsigned char bytes[16]) {
+    for (int i = 0; i < 16; i++) {
+        printf("%02x", bytes[i]);
+        if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+    }
+}
+
+int main() {
+    int count = 0;
+    cudaError_t cerr = cudaGetDeviceCount(&count);
+    if (cerr != cudaSuccess) { printf("ERROR: cudaGetDeviceCount: %s\n", cudaGetErrorString(cerr)); return 1; }
+    printf("CUDA_DEVICE_COUNT=%d\n", count);
+
+    int dev = 0;
+    cudaSetDevice(dev);
+
+    CUresult cr = cuInit(0);
+    if (cr != CUDA_SUCCESS) { printf("ERROR: cuInit: %d\n", (int)cr); return 1; }
+    CUdevice cudev; cr = cuDeviceGet(&cudev, dev);
+    if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGet: %d\n", (int)cr); return 1; }
+    CUuuid uuid; cr = cuDeviceGetUuid_v2(&uuid, cudev);
+    if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGetUuid_v2: %d\n", (int)cr); return 1; }
+    printf("MIG_SLICE_UUID=MIG-"); print_uuid((const unsigned char*)uuid.bytes); printf("\n");
+
+    const int N = 1 << 16; const size_t sz = N * sizeof(float);
+    float *hA=(float*)malloc(sz), *hB=(float*)malloc(sz), *hC=(float*)malloc(sz);
+    for (int i=0;i<N;++i){hA[i]=1.0f;hB[i]=2.0f;}
+    float *dA=nullptr,*dB=nullptr,*dC=nullptr;
+    if (cudaMalloc(&dA,sz)!=cudaSuccess||cudaMalloc(&dB,sz)!=cudaSuccess||cudaMalloc(&dC,sz)!=cudaSuccess){printf("ERROR: cudaMalloc\n");return 1;}
+    cudaMemcpy(dA,hA,sz,cudaMemcpyHostToDevice); cudaMemcpy(dB,hB,sz,cudaMemcpyHostToDevice);
+    int threads=256, blocks=(N+threads-1)/threads; vecAdd<<<blocks,threads>>>(dA,dB,dC,N);
+    cerr = cudaGetLastError(); if (cerr!=cudaSuccess){printf("ERROR: kernel: %s\n", cudaGetErrorString(cerr)); return 1;}
+    cudaMemcpy(hC,dC,sz,cudaMemcpyDeviceToHost);
+    bool ok=true; for(int i=0;i<10;++i){ if(hC[i]!=3.0f){ok=false;break;} }
+    printf("VECTOR_ADD_STATUS=%s\n", ok?"OK":"FAIL");
+    cudaFree(dA); cudaFree(dB); cudaFree(dC); free(hA); free(hB); free(hC);
+    return 0;
+}
+EOF
+
+nvcc -o /tmp/print_mig_uuid /tmp/print_mig_uuid.cu -lcuda
+/tmp/print_mig_uuid
+
+while true; do echo "gpu-b running..."; sleep 300; done
+`},
+		Env: []corev1.EnvVar{
+			{
+				Name: "NODE_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.nodeName",
+					},
+				},
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceName("nvidia.com/mig-1g.5gb"): resource.MustParse("1"),
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+	}
+
+	return corev1.PodSpec{
+		Containers: []corev1.Container{containerA, containerB},
+	}
+}
+
+func verifyMigUuidInLogs(ctx context.Context, namespace, podName, containerName string) (string, error) {
+	var req *rest.Request
+	if containerName != "" {
+		req = kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Container: containerName})
+	} else {
+		req = kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	}
+	
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "MIG_SLICE_UUID=") {
+			return strings.TrimPrefix(line, "MIG_SLICE_UUID="), nil
+		}
+	}
+	return "", fmt.Errorf("MIG_SLICE_UUID not found in logs")
+}
+
+func verifyVectorAddSuccess(ctx context.Context, namespace, podName, containerName string) (bool, error) {
+	var req *rest.Request
+	if containerName != "" {
+		req = kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{Container: containerName})
+	} else {
+		req = kubeClient.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	}
+	
+	out, err := req.Do(ctx).Raw()
+	if err != nil {
+		return false, err
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "VECTOR_ADD_STATUS=") {
+			status := strings.TrimPrefix(line, "VECTOR_ADD_STATUS=")
+			return status == "OK", nil
+		}
+	}
+	return false, fmt.Errorf("VECTOR_ADD_STATUS not found in logs")
+}

--- a/test/test-deployment-mig-uuid-verification-dual.yaml
+++ b/test/test-deployment-mig-uuid-verification-dual.yaml
@@ -1,0 +1,180 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mig-uuid-verification-dual-deployment
+  namespace: default
+  labels:
+    app: mig-uuid-verification-dual
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mig-uuid-verification-dual
+  template:
+    metadata:
+      labels:
+        app: mig-uuid-verification-dual
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - mig-uuid-verification-dual
+            topologyKey: kubernetes.io/hostname
+      restartPolicy: Always
+      containers:
+      - name: mig-uuid-printer
+        image: "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+        command: ["sh", "-c"]
+        args:
+          - |
+            echo "=== MIG UUID Dual-Slice Test (Pod: $HOSTNAME) ==="
+            echo "This container will print the MIG slice UUIDs for all visible CUDA devices using CUDA Driver API"
+            echo "Pod hostname: $HOSTNAME"
+            echo "Node name: $NODE_NAME"
+            echo ""
+            echo "Environment Variables:"
+            echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+            echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+            echo ""
+            echo "Expected: CUDA_VISIBLE_DEVICES should be '0,1'"
+            echo "Expected: Two MIG UUIDs matching NVIDIA_VISIBLE_DEVICES entries"
+            echo ""
+
+            # Create and compile CUDA program to print all MIG UUIDs
+            cat > /tmp/print_all_mig_uuid.cu << 'EOF'
+            // Assumes latest CUDA/driver with cuDeviceGetUuid_v2
+            #include <cuda.h>
+            #include <cuda_runtime.h>
+            #include <stdio.h>
+            #include <stdlib.h>
+
+            __global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                if (i < N) C[i] = A[i] + B[i];
+            }
+
+            static void print_uuid(const unsigned char bytes[16]) {
+                for (int i = 0; i < 16; i++) {
+                    printf("%02x", bytes[i]);
+                    if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+                }
+            }
+
+            int main() {
+                int count = 0;
+                cudaError_t cerr = cudaGetDeviceCount(&count);
+                if (cerr != cudaSuccess) {
+                    printf("ERROR: cudaGetDeviceCount failed: %s\n", cudaGetErrorString(cerr));
+                    return 1;
+                }
+                printf("CUDA_DEVICE_COUNT=%d\n", count);
+
+                CUresult cr = cuInit(0);
+                if (cr != CUDA_SUCCESS) {
+                    printf("ERROR: cuInit failed: %d\n", (int)cr);
+                    return 1;
+                }
+
+                for (int dev = 0; dev < count; ++dev) {
+                    cudaSetDevice(dev);
+                    CUdevice cudev;
+                    cr = cuDeviceGet(&cudev, dev);
+                    if (cr != CUDA_SUCCESS) {
+                        printf("ERROR: cuDeviceGet(%d) failed: %d\n", dev, (int)cr);
+                        continue;
+                    }
+                    CUuuid uuid;
+                    cr = cuDeviceGetUuid_v2(&uuid, cudev);
+                    if (cr != CUDA_SUCCESS) {
+                        printf("ERROR: cuDeviceGetUuid_v2(%d) failed: %d\n", dev, (int)cr);
+                        continue;
+                    }
+                    printf("MIG_DEVICE_%d_UUID=MIG-", dev);
+                    print_uuid((const unsigned char*)uuid.bytes);
+                    printf("\n");
+
+                    // Minimal vector add on this device
+                    const int N = 1 << 16;
+                    const size_t size = N * sizeof(float);
+                    float *h_A = (float*)malloc(size);
+                    float *h_B = (float*)malloc(size);
+                    float *h_C = (float*)malloc(size);
+                    if (!h_A || !h_B || !h_C) {
+                        printf("ERROR: Host allocation failed on device %d\n", dev);
+                        return 1;
+                    }
+                    for (int i = 0; i < N; ++i) { h_A[i] = 1.0f; h_B[i] = 2.0f; }
+                    float *d_A = nullptr, *d_B = nullptr, *d_C = nullptr;
+                    if (cudaMalloc(&d_A, size) != cudaSuccess ||
+                        cudaMalloc(&d_B, size) != cudaSuccess ||
+                        cudaMalloc(&d_C, size) != cudaSuccess) {
+                        printf("ERROR: Device allocation failed on device %d\n", dev);
+                        return 1;
+                    }
+                    cerr = cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+                    if (cerr != cudaSuccess) { printf("ERROR: memcpy H2D A on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+                    cerr = cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+                    if (cerr != cudaSuccess) { printf("ERROR: memcpy H2D B on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+                    int threads = 256; int blocks = (N + threads - 1) / threads;
+                    vecAdd<<<blocks, threads>>>(d_A, d_B, d_C, N);
+                    cerr = cudaGetLastError();
+                    if (cerr != cudaSuccess) { printf("ERROR: Kernel launch on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+                    cerr = cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+                    if (cerr != cudaSuccess) { printf("ERROR: memcpy D2H C on dev %d: %s\n", dev, cudaGetErrorString(cerr)); return 1; }
+                    bool ok = true; for (int i = 0; i < 10; ++i) { if (h_C[i] != 3.0f) { ok = false; break; } }
+                    printf("VECTOR_ADD_STATUS_DEV_%d=%s\n", dev, ok ? "OK" : "FAIL");
+                    cudaFree(d_A); cudaFree(d_B); cudaFree(d_C);
+                    free(h_A); free(h_B); free(h_C);
+                }
+
+                const char* nvv = getenv("NVIDIA_VISIBLE_DEVICES");
+                const char* cvv = getenv("CUDA_VISIBLE_DEVICES");
+                printf("NVIDIA_VISIBLE_DEVICES=%s\n", nvv ? nvv : "NOT_SET");
+                printf("CUDA_VISIBLE_DEVICES=%s\n", cvv ? cvv : "NOT_SET");
+                printf("POD_HOSTNAME=%s\n", getenv("HOSTNAME"));
+                printf("NODE_NAME=%s\n", getenv("NODE_NAME"));
+                return 0;
+            }
+            EOF
+
+            echo "Compiling CUDA program..."
+            nvcc -o /tmp/print_all_mig_uuid /tmp/print_all_mig_uuid.cu -lcuda
+
+            echo "Running MIG UUID extraction across all visible devices..."
+            /tmp/print_all_mig_uuid
+
+            echo ""
+            echo "=== Test Summary for Pod: $HOSTNAME ==="
+            echo "This pod should have:"
+            echo "- CUDA_VISIBLE_DEVICES=0,1"
+            echo "- Two distinct MIG_DEVICE_0_UUID and MIG_DEVICE_1_UUID"
+            echo "- Successful CUDA operations on both devices"
+            echo ""
+
+            # Keep running to allow log inspection
+            while true; do
+              echo "Pod $HOSTNAME is running with two MIG slices..."
+              sleep 300
+            done
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          limits:
+            # Request one of each MIG slice
+            nvidia.com/mig-1g.5gb: "2"
+            # nvidia.com/mig-2g.10gb: "1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+

--- a/test/test-deployment-mig-uuid-verification-multicontainer.yaml
+++ b/test/test-deployment-mig-uuid-verification-multicontainer.yaml
@@ -1,0 +1,183 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mig-uuid-verification-multicontainer
+  namespace: default
+  labels:
+    app: mig-uuid-verification-multicontainer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mig-uuid-verification-multicontainer
+  template:
+    metadata:
+      labels:
+        app: mig-uuid-verification-multicontainer
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: gpu-a
+        image: "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+        command: ["sh", "-c"]
+        args:
+          - |
+            echo "=== Multi-Container MIG Test (Container: gpu-a, Pod: $HOSTNAME) ==="
+            echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+            echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+            
+            cat > /tmp/print_mig_uuid.cu << 'EOF'
+            // Assumes latest CUDA/driver with cuDeviceGetUuid_v2
+            #include <cuda.h>
+            #include <cuda_runtime.h>
+            #include <stdio.h>
+            #include <stdlib.h>
+
+            __global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                if (i < N) C[i] = A[i] + B[i];
+            }
+
+            static void print_uuid(const unsigned char bytes[16]) {
+                for (int i = 0; i < 16; i++) {
+                    printf("%02x", bytes[i]);
+                    if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+                }
+            }
+
+            int main() {
+                // Expect exactly one visible device in this container
+                int count = 0;
+                cudaError_t cerr = cudaGetDeviceCount(&count);
+                if (cerr != cudaSuccess) { printf("ERROR: cudaGetDeviceCount: %s\n", cudaGetErrorString(cerr)); return 1; }
+                printf("CUDA_DEVICE_COUNT=%d\n", count);
+
+                int dev = 0;
+                cudaSetDevice(dev);
+
+                CUresult cr = cuInit(0);
+                if (cr != CUDA_SUCCESS) { printf("ERROR: cuInit: %d\n", (int)cr); return 1; }
+                CUdevice cudev; cr = cuDeviceGet(&cudev, dev);
+                if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGet: %d\n", (int)cr); return 1; }
+                CUuuid uuid; cr = cuDeviceGetUuid_v2(&uuid, cudev);
+                if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGetUuid_v2: %d\n", (int)cr); return 1; }
+                printf("MIG_SLICE_UUID=MIG-"); print_uuid((const unsigned char*)uuid.bytes); printf("\n");
+
+                // Quick GPU op to verify access
+                const int N = 1 << 16; const size_t sz = N * sizeof(float);
+                float *hA=(float*)malloc(sz), *hB=(float*)malloc(sz), *hC=(float*)malloc(sz);
+                for (int i=0;i<N;++i){hA[i]=1.0f;hB[i]=2.0f;}
+                float *dA=nullptr,*dB=nullptr,*dC=nullptr;
+                if (cudaMalloc(&dA,sz)!=cudaSuccess||cudaMalloc(&dB,sz)!=cudaSuccess||cudaMalloc(&dC,sz)!=cudaSuccess){printf("ERROR: cudaMalloc\n");return 1;}
+                cudaMemcpy(dA,hA,sz,cudaMemcpyHostToDevice); cudaMemcpy(dB,hB,sz,cudaMemcpyHostToDevice);
+                int threads=256, blocks=(N+threads-1)/threads; vecAdd<<<blocks,threads>>>(dA,dB,dC,N);
+                cerr = cudaGetLastError(); if (cerr!=cudaSuccess){printf("ERROR: kernel: %s\n", cudaGetErrorString(cerr)); return 1;}
+                cudaMemcpy(hC,dC,sz,cudaMemcpyDeviceToHost);
+                bool ok=true; for(int i=0;i<10;++i){ if(hC[i]!=3.0f){ok=false;break;} }
+                printf("VECTOR_ADD_STATUS=%s\n", ok?"OK":"FAIL");
+                cudaFree(dA); cudaFree(dB); cudaFree(dC); free(hA); free(hB); free(hC);
+                return 0;
+            }
+            EOF
+
+            nvcc -o /tmp/print_mig_uuid /tmp/print_mig_uuid.cu -lcuda
+            /tmp/print_mig_uuid
+            
+            while true; do echo "gpu-a running..."; sleep 300; done
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          limits:
+            nvidia.com/mig-1g.5gb: "1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+
+      - name: gpu-b
+        image: "nvidia/cuda:12.4.1-devel-ubuntu22.04"
+        command: ["sh", "-c"]
+        args:
+          - |
+            echo "=== Multi-Container MIG Test (Container: gpu-b, Pod: $HOSTNAME) ==="
+            echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+            echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+            
+            cat > /tmp/print_mig_uuid.cu << 'EOF'
+            // Assumes latest CUDA/driver with cuDeviceGetUuid_v2
+            #include <cuda.h>
+            #include <cuda_runtime.h>
+            #include <stdio.h>
+            #include <stdlib.h>
+
+            __global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                if (i < N) C[i] = A[i] + B[i];
+            }
+
+            static void print_uuid(const unsigned char bytes[16]) {
+                for (int i = 0; i < 16; i++) {
+                    printf("%02x", bytes[i]);
+                    if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+                }
+            }
+
+            int main() {
+                // Expect exactly one visible device in this container
+                int count = 0;
+                cudaError_t cerr = cudaGetDeviceCount(&count);
+                if (cerr != cudaSuccess) { printf("ERROR: cudaGetDeviceCount: %s\n", cudaGetErrorString(cerr)); return 1; }
+                printf("CUDA_DEVICE_COUNT=%d\n", count);
+
+                int dev = 0;
+                cudaSetDevice(dev);
+
+                CUresult cr = cuInit(0);
+                if (cr != CUDA_SUCCESS) { printf("ERROR: cuInit: %d\n", (int)cr); return 1; }
+                CUdevice cudev; cr = cuDeviceGet(&cudev, dev);
+                if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGet: %d\n", (int)cr); return 1; }
+                CUuuid uuid; cr = cuDeviceGetUuid_v2(&uuid, cudev);
+                if (cr != CUDA_SUCCESS) { printf("ERROR: cuDeviceGetUuid_v2: %d\n", (int)cr); return 1; }
+                printf("MIG_SLICE_UUID=MIG-"); print_uuid((const unsigned char*)uuid.bytes); printf("\n");
+
+                // Quick GPU op to verify access
+                const int N = 1 << 16; const size_t sz = N * sizeof(float);
+                float *hA=(float*)malloc(sz), *hB=(float*)malloc(sz), *hC=(float*)malloc(sz);
+                for (int i=0;i<N;++i){hA[i]=1.0f;hB[i]=2.0f;}
+                float *dA=nullptr,*dB=nullptr,*dC=nullptr;
+                if (cudaMalloc(&dA,sz)!=cudaSuccess||cudaMalloc(&dB,sz)!=cudaSuccess||cudaMalloc(&dC,sz)!=cudaSuccess){printf("ERROR: cudaMalloc\n");return 1;}
+                cudaMemcpy(dA,hA,sz,cudaMemcpyHostToDevice); cudaMemcpy(dB,hB,sz,cudaMemcpyHostToDevice);
+                int threads=256, blocks=(N+threads-1)/threads; vecAdd<<<blocks,threads>>>(dA,dB,dC,N);
+                cerr = cudaGetLastError(); if (cerr!=cudaSuccess){printf("ERROR: kernel: %s\n", cudaGetErrorString(cerr)); return 1;}
+                cudaMemcpy(hC,dC,sz,cudaMemcpyDeviceToHost);
+                bool ok=true; for(int i=0;i<10;++i){ if(hC[i]!=3.0f){ok=false;break;} }
+                printf("VECTOR_ADD_STATUS=%s\n", ok?"OK":"FAIL");
+                cudaFree(dA); cudaFree(dB); cudaFree(dC); free(hA); free(hB); free(hC);
+                return 0;
+            }
+            EOF
+
+            nvcc -o /tmp/print_mig_uuid /tmp/print_mig_uuid.cu -lcuda
+            /tmp/print_mig_uuid
+            
+            while true; do echo "gpu-b running..."; sleep 300; done
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          limits:
+            nvidia.com/mig-1g.5gb: "1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+

--- a/test/test-deployment-mig-uuid-verification.yaml
+++ b/test/test-deployment-mig-uuid-verification.yaml
@@ -1,0 +1,184 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mig-uuid-verification-deployment
+  namespace: default
+  labels:
+    app: mig-uuid-verification
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: mig-uuid-verification
+  template:
+    metadata:
+      labels:
+        app: mig-uuid-verification
+    spec:
+      # Ensure all pods in this deployment run on the same node
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - mig-uuid-verification
+            topologyKey: kubernetes.io/hostname
+      restartPolicy: Always
+      containers:
+      - name: mig-uuid-printer
+        image: "nvidia/cuda:12.4.1-devel-ubuntu22.04"  # Requires real GPUs
+        command: ["sh", "-c"]
+        args:
+          - |
+            echo "=== MIG UUID Verification Test (Pod: $HOSTNAME) ==="
+            echo "This container will print the actual MIG slice UUID using CUDA APIs"
+            echo "Pod hostname: $HOSTNAME"
+            echo "Node name: $NODE_NAME"
+            echo ""
+            echo "Environment Variables:"
+            echo "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES"
+            echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+            echo ""
+            echo "Expected: CUDA_VISIBLE_DEVICES should be '0' for both pods"
+            echo "Expected: MIG_SLICE_UUID should be DIFFERENT for each pod"
+            echo ""
+
+            # Create and compile CUDA program to print MIG UUID
+            cat > /tmp/print_mig_uuid.cu << 'EOF'
+            // Assume latest CUDA/driver with cuDeviceGetUuid_v2 available
+            #include <cuda.h>
+            #include <cuda_runtime.h>
+            #include <stdio.h>
+            #include <stdlib.h>
+
+            __global__ void vecAdd(const float* A, const float* B, float* C, int N) {
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                if (i < N) C[i] = A[i] + B[i];
+            }
+
+            int main() {
+                // Select device 0 (should be the MIG device exposed to the pod)
+                int dev = 0;
+                cudaSetDevice(dev);
+
+                // Use CUDA Driver API to get MIG UUID via cuDeviceGetUuid_v2
+                CUresult cr;
+                cr = cuInit(0);
+                if (cr != CUDA_SUCCESS) {
+                    printf("ERROR: cuInit failed: %d\n", (int)cr);
+                    return 1;
+                }
+                CUdevice cudev;
+                cr = cuDeviceGet(&cudev, dev);
+                if (cr != CUDA_SUCCESS) {
+                    printf("ERROR: cuDeviceGet failed: %d\n", (int)cr);
+                    return 1;
+                }
+                CUuuid u2;
+                cr = cuDeviceGetUuid_v2(&u2, cudev);
+                if (cr != CUDA_SUCCESS) {
+                    printf("ERROR: cuDeviceGetUuid_v2 failed: %d\n", (int)cr);
+                    return 1;
+                }
+                printf("MIG_SLICE_UUID=MIG-");
+                for (int i = 0; i < 16; i++) {
+                    printf("%02x", (unsigned char)u2.bytes[i]);
+                    if (i == 3 || i == 5 || i == 7 || i == 9) printf("-");
+                }
+                printf("\n");
+
+                char* nvidia_visible = getenv("NVIDIA_VISIBLE_DEVICES");
+                char* cuda_visible = getenv("CUDA_VISIBLE_DEVICES");
+                printf("NVIDIA_VISIBLE_DEVICES=%s\n", nvidia_visible ? nvidia_visible : "NOT_SET");
+                printf("CUDA_VISIBLE_DEVICES=%s\n", cuda_visible ? cuda_visible : "NOT_SET");
+                printf("POD_HOSTNAME=%s\n", getenv("HOSTNAME"));
+                printf("NODE_NAME=%s\n", getenv("NODE_NAME"));
+
+                // Minimal GPU test: vector addition
+                const int N = 1 << 16;
+                const size_t size = N * sizeof(float);
+                float *h_A = (float*)malloc(size);
+                float *h_B = (float*)malloc(size);
+                float *h_C = (float*)malloc(size);
+                if (!h_A || !h_B || !h_C) {
+                    printf("ERROR: Host allocation failed\n");
+                    return 1;
+                }
+                for (int i = 0; i < N; ++i) { h_A[i] = 1.0f; h_B[i] = 2.0f; }
+
+                float *d_A = nullptr, *d_B = nullptr, *d_C = nullptr;
+                if (cudaMalloc(&d_A, size) != cudaSuccess ||
+                    cudaMalloc(&d_B, size) != cudaSuccess ||
+                    cudaMalloc(&d_C, size) != cudaSuccess) {
+                    printf("ERROR: Device allocation failed\n");
+                    return 1;
+                }
+                cudaError_t err;
+                err = cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+                if (err != cudaSuccess) { printf("ERROR: memcpy H2D A: %s\n", cudaGetErrorString(err)); return 1; }
+                err = cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+                if (err != cudaSuccess) { printf("ERROR: memcpy H2D B: %s\n", cudaGetErrorString(err)); return 1; }
+                int threads = 256; int blocks = (N + threads - 1) / threads;
+                vecAdd<<<blocks, threads>>>(d_A, d_B, d_C, N);
+                err = cudaGetLastError();
+                if (err != cudaSuccess) {
+                    printf("ERROR: Kernel launch failed: %s\n", cudaGetErrorString(err));
+                    return 1;
+                }
+                err = cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+                if (err != cudaSuccess) { printf("ERROR: memcpy D2H C: %s\n", cudaGetErrorString(err)); return 1; }
+                // Verify a few entries
+                bool ok = true;
+                for (int i = 0; i < 10; ++i) {
+                    if (h_C[i] != 3.0f) { ok = false; break; }
+                }
+                printf("VECTOR_ADD_STATUS=%s\n", ok ? "OK" : "FAIL");
+
+                cudaFree(d_A); cudaFree(d_B); cudaFree(d_C);
+                free(h_A); free(h_B); free(h_C);
+                return 0;
+            }
+            EOF
+
+            echo "Compiling CUDA program..."
+            nvcc -o /tmp/print_mig_uuid /tmp/print_mig_uuid.cu -lcuda
+
+            echo "Running MIG UUID extraction..."
+            /tmp/print_mig_uuid
+
+            echo ""
+            echo "GPU verification done in the CUDA program above."
+
+            echo ""
+            echo "=== Test Summary for Pod: $HOSTNAME ==="
+            echo "This pod should have:"
+            echo "- CUDA_VISIBLE_DEVICES=0 (indexed from 0)"
+            echo "- A unique MIG_SLICE_UUID (different from other pods)"
+            echo "- Successful CUDA operations"
+            echo ""
+            echo "Compare logs from both pods to verify different UUIDs!"
+            echo ""
+
+            # Keep running to allow log comparison
+            while true; do
+              echo "Pod $HOSTNAME is running with MIG slice access..."
+              sleep 300  # Log every 5 minutes
+            done
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          limits:
+            # Each pod requests a single MIG slice
+            nvidia.com/mig-1g.5gb: "1"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
This PR changes the way CUDA_VISIBLE_DEVICES is set in the CDI spec. Instead of using MIG-UUID, it now uses index. With this fix, OpenAI's gpt-oss 20b model with latest vllm runs fine with 7g.40gb slice on an A100. 

```bash
$ curl -X POST http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{"model": "openai/gpt-oss-20b", "prompt": "The capital of France is", "max_tokens": 10, "temperature": 0.7}' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   567  100   460  100   107   1364    317 --:--:-- --:--:-- --:--:--  1677
{
  "id": "cmpl-fb79e5a3a13c48919ebe25319c4cdb8b",
  "object": "text_completion",
  "created": 1755717317,
  "model": "openai/gpt-oss-20b",
  "choices": [
    {
      "index": 0,
      "text": " Paris.\"\n\n```java\npublic class Sentence {\n   ",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "prompt_logprobs": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 5,
    "total_tokens": 15,
    "completion_tokens": 10,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}

```