### PR TITLE
OCPNODE-3597: Filter CDI specs that match Device Plugin server's managed resource 

### DIFF
--- a/pkg/daemonset/deviceplugins/server.go
+++ b/pkg/daemonset/deviceplugins/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,18 +138,34 @@ func (s *Server) ListAndWatch(req *pluginapi.Empty, stream pluginapi.DevicePlugi
 	// build initial device list from existing CDI spec files
 	var initDevices []*pluginapi.Device
 	cache := cdi.GetDefaultCache()
-	for _, vendor := range cache.ListVendors() {
-		klog.V(4).InfoS("Enumerating CDI specs", "vendor", vendor)
-		for _, spec := range cache.GetVendorSpecs(vendor) {
+
+	// Get the expected sanitized class name for this server's resource
+	vendor, class := parser.ParseQualifier(s.Manager.ResourceName)
+	sanitizedClass := class
+	if err := parser.ValidateClassName(sanitizedClass); err != nil {
+		sanitizedClass = "c" + sanitizedClass
+	}
+	expectedKind := sanitizedClass
+	if vendor != "" {
+		expectedKind = vendor + "/" + sanitizedClass
+	}
+
+	for _, v := range cache.ListVendors() {
+		klog.V(4).InfoS("Enumerating CDI specs", "vendor", v)
+		for _, spec := range cache.GetVendorSpecs(v) {
+			// Filter CDI specs to only include those relevant to this server's resource
+			if spec.Spec.Kind != expectedKind {
+				klog.V(5).InfoS("Skipping CDI spec for different resource", "specKind", spec.Spec.Kind, "expectedKind", expectedKind, "path", spec.GetPath())
+				continue
+			}
 			id := filepath.Base(spec.GetPath())
-			klog.V(4).InfoS("Adding device from spec", "path", spec.GetPath(), "id", id)
+			klog.V(4).InfoS("Adding device from spec", "path", spec.GetPath(), "id", id, "kind", spec.Spec.Kind)
 			initDevices = append(initDevices, &pluginapi.Device{ID: id, Health: pluginapi.Healthy})
 		}
 	}
 
 	// Detect system reboot by comparing in-use allocations with on-disk CDI specs
-	// TODO : filter out CDI specs and AllocationClaims that are not relevant to this server's resource
-	// because it will race with other servers that will be running on the same node.
+	// CDI specs and AllocationClaims are now filtered to only include those relevant to this server's resource
 	migProfile := profileFromResourceName(s.Manager.ResourceName)
 	migProfile = unsanitizeProfileName(migProfile)
 	key := fmt.Sprintf("%s/%s", s.NodeName, migProfile)
@@ -173,6 +190,21 @@ func (s *Server) ListAndWatch(req *pluginapi.Empty, stream pluginapi.DevicePlugi
 
 	if len(inUseAllocs) != len(initDevices) {
 		klog.InfoS("Detected reboot, deleting allocations", "resource", s.Manager.ResourceName, "inUse", len(inUseAllocs), "specs", len(initDevices))
+
+		// Collect pod references for deletion before deleting allocations
+		var podsToDelete []corev1.ObjectReference
+		for _, alloc := range inUseAllocs {
+			spec, err := getAllocationClaimSpec(alloc)
+			if err != nil {
+				klog.ErrorS(err, "failed to decode allocation spec", "allocation", alloc.Name)
+				continue
+			}
+			if spec.PodRef.Name != "" && spec.PodRef.Namespace != "" {
+				podsToDelete = append(podsToDelete, spec.PodRef)
+			}
+		}
+
+		// Delete AllocationClaims
 		for _, alloc := range inUseAllocs {
 			err := s.InstasliceClient.OpenShiftOperatorV1alpha1().AllocationClaims(alloc.Namespace).Delete(stream.Context(), alloc.Name, metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
@@ -183,6 +215,26 @@ func (s *Server) ListAndWatch(req *pluginapi.Empty, stream pluginapi.DevicePlugi
 			s.allocMutex.Lock()
 			allocationIndexer.Delete(alloc)
 			s.allocMutex.Unlock()
+		}
+
+		// Delete associated pods to mitigate kubelet bug which is admits the pods before the device plugin is ready
+		// https://github.com/kubernetes/kubernetes/issues/128043
+		// TODO - Remove this once the kubelet bug is fixed
+		if len(podsToDelete) > 0 {
+			klog.InfoS("Deleting pods associated with stale allocations", "resource", s.Manager.ResourceName, "podCount", len(podsToDelete))
+			for _, podRef := range podsToDelete {
+				err := s.KubeClient.CoreV1().Pods(podRef.Namespace).Delete(stream.Context(), podRef.Name, metav1.DeleteOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						klog.V(4).InfoS("Pod already deleted", "pod", podRef.Name, "namespace", podRef.Namespace)
+					} else {
+						// Log error but continue with other pod deletions
+						klog.ErrorS(err, "failed to delete pod on reboot", "pod", podRef.Name, "namespace", podRef.Namespace)
+					}
+				} else {
+					klog.InfoS("Deleted pod on reboot detection", "pod", podRef.Name, "namespace", podRef.Namespace)
+				}
+			}
 		}
 	}
 

--- a/pkg/daemonset/deviceplugins/server_test.go
+++ b/pkg/daemonset/deviceplugins/server_test.go
@@ -11,6 +11,10 @@ import (
 	"time"
 
 	"google.golang.org/grpc/metadata"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 	cdispec "tags.cncf.io/container-device-interface/specs-go"
@@ -20,7 +24,6 @@ import (
 	instav1 "github.com/openshift/instaslice-operator/pkg/apis/dasoperator/v1alpha1"
 	fakeclient "github.com/openshift/instaslice-operator/pkg/generated/clientset/versioned/fake"
 	utils "github.com/openshift/instaslice-operator/test/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -442,6 +445,268 @@ func TestWriteCDISpecForResourceWait(t *testing.T) {
 
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected spec recreated: %v", err)
+	}
+}
+
+func TestListAndWatchFiltersSpecsByResource(t *testing.T) {
+	dir := t.TempDir()
+	if err := cdi.Configure(cdi.WithSpecDirs(dir), cdi.WithAutoRefresh(false)); err != nil {
+		t.Fatalf("failed to configure cdi: %v", err)
+	}
+
+	// Create CDI specs for different resource types
+	spec1Path, _, err := WriteCDISpecForResource("mig.das.com/1g.5gb", "id1", nil, "")
+	if err != nil {
+		t.Fatalf("failed to write spec1: %v", err)
+	}
+
+	spec2Path, _, err := WriteCDISpecForResource("mig.das.com/3g.20gb", "id2", nil, "")
+	if err != nil {
+		t.Fatalf("failed to write spec2: %v", err)
+	}
+
+	spec3Path, _, err := WriteCDISpecForResource("mig.das.com/1g.5gb", "id3", nil, "")
+	if err != nil {
+		t.Fatalf("failed to write spec3: %v", err)
+	}
+
+	// Create a server for the 1g.5gb resource
+	mgr := NewManager("mig.das.com/1g.5gb", instav1.DiscoveredNodeResources{})
+	srv := &Server{Manager: mgr}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newFakeListWatchServer(ctx)
+	done := make(chan error, 1)
+	go func() { done <- srv.ListAndWatch(&pluginapi.Empty{}, stream) }()
+
+	var resp *pluginapi.ListAndWatchResponse
+	select {
+	case resp = <-stream.ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for initial response")
+	}
+
+	// Should only see devices from specs that match the server's resource (1g.5gb)
+	expectedIDs := []string{filepath.Base(spec1Path), filepath.Base(spec3Path)}
+	if len(resp.Devices) != 2 {
+		t.Fatalf("expected 2 devices, got %d: %+v", len(resp.Devices), resp.Devices)
+	}
+
+	// Verify the correct devices are included
+	actualIDs := make([]string, len(resp.Devices))
+	for i, dev := range resp.Devices {
+		actualIDs[i] = dev.ID
+		if dev.Health != pluginapi.Healthy {
+			t.Fatalf("expected device %s to be healthy", dev.ID)
+		}
+	}
+
+	// Check that we got the expected IDs (order doesn't matter)
+	for _, expectedID := range expectedIDs {
+		found := false
+		for _, actualID := range actualIDs {
+			if actualID == expectedID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected device ID %s not found in actual devices %v", expectedID, actualIDs)
+		}
+	}
+
+	// Verify that the 3g.20gb spec was filtered out
+	spec2ID := filepath.Base(spec2Path)
+	for _, actualID := range actualIDs {
+		if actualID == spec2ID {
+			t.Fatalf("unexpected device ID %s found - should have been filtered out", spec2ID)
+		}
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("ListAndWatch returned error: %v", err)
+	}
+}
+
+func TestListAndWatchFiltersSpecsWithDifferentVendors(t *testing.T) {
+	dir := t.TempDir()
+	if err := cdi.Configure(cdi.WithSpecDirs(dir), cdi.WithAutoRefresh(false)); err != nil {
+		t.Fatalf("failed to configure cdi: %v", err)
+	}
+
+	// Create CDI specs for different vendors and classes
+	spec1Path, _, err := WriteCDISpecForResource("vendor1/class1", "id1", nil, "")
+	if err != nil {
+		t.Fatalf("failed to write spec1: %v", err)
+	}
+
+	spec2Path, _, err := WriteCDISpecForResource("vendor2/class1", "id2", nil, "")
+	if err != nil {
+		t.Fatalf("failed to write spec2: %v", err)
+	}
+
+	spec3Path, _, err := WriteCDISpecForResource("vendor1/class1", "id3", nil, "")
+	if err != nil {
+		t.Fatalf("failed to write spec3: %v", err)
+	}
+
+	// Create a server for vendor1/class1
+	mgr := NewManager("vendor1/class1", instav1.DiscoveredNodeResources{})
+	srv := &Server{Manager: mgr}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newFakeListWatchServer(ctx)
+	done := make(chan error, 1)
+	go func() { done <- srv.ListAndWatch(&pluginapi.Empty{}, stream) }()
+
+	var resp *pluginapi.ListAndWatchResponse
+	select {
+	case resp = <-stream.ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for initial response")
+	}
+
+	// Should only see devices from vendor1/class1 specs
+	expectedIDs := []string{filepath.Base(spec1Path), filepath.Base(spec3Path)}
+	if len(resp.Devices) != 2 {
+		t.Fatalf("expected 2 devices, got %d: %+v", len(resp.Devices), resp.Devices)
+	}
+
+	// Verify the correct devices are included
+	actualIDs := make([]string, len(resp.Devices))
+	for i, dev := range resp.Devices {
+		actualIDs[i] = dev.ID
+	}
+
+	// Check that we got the expected IDs
+	for _, expectedID := range expectedIDs {
+		found := false
+		for _, actualID := range actualIDs {
+			if actualID == expectedID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected device ID %s not found in actual devices %v", expectedID, actualIDs)
+		}
+	}
+
+	// Verify that the vendor2/class1 spec was filtered out
+	spec2ID := filepath.Base(spec2Path)
+	for _, actualID := range actualIDs {
+		if actualID == spec2ID {
+			t.Fatalf("unexpected device ID %s found - should have been filtered out", spec2ID)
+		}
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("ListAndWatch returned error: %v", err)
+	}
+}
+
+func TestListAndWatchRebootDeletesPods(t *testing.T) {
+	dir := t.TempDir()
+	if err := cdi.Configure(cdi.WithSpecDirs(dir), cdi.WithAutoRefresh(false)); err != nil {
+		t.Fatalf("failed to configure cdi: %v", err)
+	}
+
+	// Create a fake AllocationClaim with pod reference
+	alloc := &instav1.AllocationClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-alloc",
+			Namespace: "test-ns",
+		},
+		Status: instav1.AllocationClaimStatus{
+			State: instav1.AllocationClaimStatusInUse,
+		},
+	}
+
+	// Create spec with pod reference
+	spec := instav1.AllocationClaimSpec{
+		Profile:  "1g.5gb",
+		Nodename: "test-node",
+		PodRef: corev1.ObjectReference{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+	}
+	specBytes, _ := json.Marshal(spec)
+	alloc.Spec.Raw = specBytes
+
+	// Setup indexer and add allocation
+	allocationIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		"node-MigProfile": func(obj interface{}) ([]string, error) {
+			a := obj.(*instav1.AllocationClaim)
+			spec, err := getAllocationClaimSpec(a)
+			if err != nil {
+				return nil, err
+			}
+			key := fmt.Sprintf("%s/%s", spec.Nodename, spec.Profile)
+			return []string{key}, nil
+		},
+	})
+	defer func() { allocationIndexer = nil }()
+	allocationIndexer.Add(alloc)
+
+	// Create fake Kubernetes client
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create the test pod
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+		},
+	}
+	_, err := fakeClient.CoreV1().Pods("test-ns").Create(context.Background(), testPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create test pod: %v", err)
+	}
+
+	// Create server with fake clients
+	mgr := NewManager("mig.das.com/1g.5gb", instav1.DiscoveredNodeResources{})
+	srv := &Server{
+		Manager:          mgr,
+		InstasliceClient: fakeclient.NewSimpleClientset(),
+		KubeClient:       fakeClient,
+		NodeName:         "test-node",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream := newFakeListWatchServer(ctx)
+	done := make(chan error, 1)
+	go func() { done <- srv.ListAndWatch(&pluginapi.Empty{}, stream) }()
+
+	var resp *pluginapi.ListAndWatchResponse
+	select {
+	case resp = <-stream.ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for initial response")
+	}
+
+	// Should have 0 devices since we have 1 inUse allocation but 0 CDI specs (reboot scenario)
+	if len(resp.Devices) != 0 {
+		t.Fatalf("expected 0 devices due to reboot detection, got %d", len(resp.Devices))
+	}
+
+	// Verify the pod was deleted
+	_, err = fakeClient.CoreV1().Pods("test-ns").Get(context.Background(), "test-pod", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected pod to be deleted, but got error: %v", err)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("ListAndWatch returned error: %v", err)
 	}
 }
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -174,7 +174,7 @@ var _ = Describe("Test pods for requesting single type of extended resource", Or
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -217,7 +217,7 @@ var _ = Describe("Test pods for requesting single type of extended resource", Or
 		for _, name := range podNames {
 			Eventually(func() (bool, error) {
 				return verifyVisibleDevicesEnv(ctx, namespace, name, 0)
-			}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 		}
 	})
 
@@ -330,7 +330,7 @@ var _ = Describe("Test deployment requesting single type of extended resource", 
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -373,7 +373,7 @@ var _ = Describe("Test deployment requesting single type of extended resource", 
 		for _, name := range podNames {
 			Eventually(func() (bool, error) {
 				return verifyVisibleDevicesEnv(ctx, namespace, name, 0)
-			}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 		}
 	})
 })
@@ -436,7 +436,7 @@ var _ = Describe("Test pods requesting multiple resources", Ordered, func() {
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -457,7 +457,7 @@ var _ = Describe("Test pods requesting multiple resources", Ordered, func() {
 		for _, name := range podNames {
 			Eventually(func() (bool, error) {
 				return verifyVisibleDevicesEnv(ctx, namespace, name, 3)
-			}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+			}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 		}
 	})
 })
@@ -534,7 +534,7 @@ var _ = Describe("Test pods for requesting multiple slice types", Ordered, func(
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -726,7 +726,7 @@ var _ = Describe("MIG placement start index", Ordered, func() {
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -760,7 +760,7 @@ var _ = Describe("MIG placement start index", Ordered, func() {
 				found++
 			}
 			return found == len(podNames), nil
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 })
 
@@ -807,7 +807,7 @@ var _ = Describe("MIG UUID verification", Ordered, func() {
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -823,13 +823,13 @@ var _ = Describe("MIG UUID verification", Ordered, func() {
 	It("should have NVIDIA_VISIBLE_DEVICES matching MIG_SLICE_UUID", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyMigUuidMatches(ctx, namespace, podName)
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	It("should successfully run vector addition", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyVectorAddSuccess(ctx, namespace, podName, "")
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 })
 
@@ -876,7 +876,7 @@ var _ = Describe("MIG UUID dual slice verification", Ordered, func() {
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -892,19 +892,19 @@ var _ = Describe("MIG UUID dual slice verification", Ordered, func() {
 	It("should report 2 CUDA devices", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyDualSliceCudaDeviceCount(ctx, namespace, podName)
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	It("should have NVIDIA_VISIBLE_DEVICES matching MIG device UUIDs", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyDualSliceMigUuidMatches(ctx, namespace, podName)
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	It("should successfully run vector addition on both devices", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyDualSliceVectorAddSuccess(ctx, namespace, podName)
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 })
 
@@ -951,7 +951,7 @@ var _ = Describe("MIG UUID multi-container verification", Ordered, func() {
 		Eventually(func() bool {
 			_, err := kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 			return apierrors.IsNotFound(err)
-		}, 2*time.Minute, time.Second).Should(BeTrue())
+		}, 5*time.Minute, time.Second).Should(BeTrue())
 	})
 
 	It("should be running", func(ctx SpecContext) {
@@ -967,25 +967,25 @@ var _ = Describe("MIG UUID multi-container verification", Ordered, func() {
 	It("should have NVIDIA_VISIBLE_DEVICES matching MIG_SLICE_UUID in gpu-a container", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyMulticontainerMigUuidMatches(ctx, namespace, podName, "gpu-a")
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	It("should have NVIDIA_VISIBLE_DEVICES matching MIG_SLICE_UUID in gpu-b container", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyMulticontainerMigUuidMatches(ctx, namespace, podName, "gpu-b")
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	It("should successfully run vector addition in gpu-a container", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyVectorAddSuccess(ctx, namespace, podName, "gpu-a")
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 
 	It("should successfully run vector addition in gpu-b container", func(ctx SpecContext) {
 		Eventually(func() (bool, error) {
 			return verifyVectorAddSuccess(ctx, namespace, podName, "gpu-b")
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 })
 
@@ -1037,7 +1037,7 @@ var _ = Describe("Operator status", Ordered, func() {
 			}
 
 			return true, nil
-		}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
 	})
 })
 


### PR DESCRIPTION
Two changes in this PR, 
1. Filter CDI specs that match with the device plugin's resource before deleting them after a reboot. 
2. Clean up the pods that shouldn't have been admitted by the kubelet, but are due to https://github.com/kubernetes/kubernetes/issues/128043 


With this change, when the pods with external controller crash due to https://github.com/kubernetes/kubernetes/issues/128043, the device plugin actively deletes the known pod that has been incorrectly admitted by the kubelet, this speeds up the recovery of such pods. 

Reboot testing results, 

Kubelet admits the pods before device plugin is ready, due to https://github.com/kubernetes/kubernetes/issues/128043
```
harshal@control-plane:~/Projects/instaslice/OCPNODE-3597$ kubectl get pods 
NAME                              READY   STATUS                     RESTARTS   AGE
cuda-vectoradd-6b88887647-hf4bx   0/1     UnexpectedAdmissionError   0          4m39s
cuda-vectoradd-6b88887647-s2mr4   0/1     Pending                    0          27s
cuda-vectoradd-6b88887647-s8jw4   0/1     Pending                    0          28s
cuda-vectoradd-6b88887647-x99zg   0/1     UnexpectedAdmissionError   0          4m39s
```
but as soon as the DAS device plugin is up, it cleans up the pods that it knows should have been never admitted. 

```

harshal@control-plane:~/Projects/instaslice/OCPNODE-3597$ kubectl get pods 
NAME                              READY   STATUS    RESTARTS   AGE
cuda-vectoradd-6b88887647-s2mr4   1/1     Running   0          3m27s
cuda-vectoradd-6b88887647-s8jw4   1/1     Running   0          3m28s
```

/hold for OCP upgrade testing. 