### PR TITLE
force "docker" format for buildah

### DIFF
--- a/.tekton/instaslice-daemonset-next-pull-request.yaml
+++ b/.tekton/instaslice-daemonset-next-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-daemonset-next-push.yaml
+++ b/.tekton/instaslice-daemonset-next-push.yaml
@@ -212,6 +212,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-operator-bundle-developer-next-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-developer-next-pull-request.yaml
@@ -218,6 +218,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-operator-bundle-developer-next-push.yaml
+++ b/.tekton/instaslice-operator-bundle-developer-next-push.yaml
@@ -215,6 +215,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-operator-bundle-next-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-next-pull-request.yaml
@@ -217,6 +217,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-operator-bundle-next-push.yaml
+++ b/.tekton/instaslice-operator-bundle-next-push.yaml
@@ -214,6 +214,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-operator-next-pull-request.yaml
+++ b/.tekton/instaslice-operator-next-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-operator-next-push.yaml
+++ b/.tekton/instaslice-operator-next-push.yaml
@@ -212,6 +212,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-scheduler-next-pull-request.yaml
+++ b/.tekton/instaslice-scheduler-next-pull-request.yaml
@@ -227,6 +227,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-scheduler-next-push.yaml
+++ b/.tekton/instaslice-scheduler-next-push.yaml
@@ -226,6 +226,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-webhook-next-pull-request.yaml
+++ b/.tekton/instaslice-webhook-next-pull-request.yaml
@@ -213,6 +213,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT

--- a/.tekton/instaslice-webhook-next-push.yaml
+++ b/.tekton/instaslice-webhook-next-push.yaml
@@ -212,6 +212,8 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: FORMAT
+        value: docker
       - name: PRIVILEGED_NESTED
         value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT


### PR DESCRIPTION
Looking at tekton buildah docs, setting FORMAT should switch to "docker" format. 

https://github.com/tektoncd/catalog/blob/ecbce9e4ae4d59edab0a9d1e0ef3ca5d644e03fd/task/buildah/0.7/buildah.yaml#L43 