### PR TITLE
OCPNODE-4184: Sync libnvidia-ml to 580.126.20 for GPU Operator 26.3.0(OCP-4.21)

### DIFF
--- a/Dockerfile.daemonset.ocp
+++ b/Dockerfile.daemonset.ocp
@@ -18,8 +18,8 @@ RUN printf '%s\n' \
   > /etc/yum.repos.d/cuda-rhel-9.repo
 
 # NVIDIA driver version must match GPU Operator installation
-# GPU Operator 25.10.1 uses driver 580.105.08 (see https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/release-notes.html)
-ARG NVIDIA_DRIVER_VERSION=580.105.08
+# GPU Operator 26.3.0 uses driver 580.126.20 (see https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/release-notes.html)
+ARG NVIDIA_DRIVER_VERSION=580.126.20
 
 # Install libnvidia-ml package from internal CUDA repo
 # Version must match konflux/rpms.lock.yaml for hermetic builds with cachi2

--- a/konflux/rpms.lock.yaml
+++ b/konflux/rpms.lock.yaml
@@ -18,15 +18,15 @@ arches:
     name: jq
     evr: 1.6-19.el9
     sourcerpm: jq-1.6-19.el9.src.rpm
-  # NVIDIA driver version must match GPU Operator 25.10.1 (driver 580.105.08)
+  # NVIDIA driver version must match GPU Operator 26.3.0 (driver 580.126.20)
   # See NVIDIA_DRIVER_VERSION in Dockerfile.daemonset.ocp
-  - url: https://internal.console.redhat.com/api/pulp-content/rhel-ai/cuda-rhel-9-x86_64/Packages/l/libnvidia-ml-580.105.08-1.el9.x86_64.rpm
+  - url: https://internal.console.redhat.com/api/pulp-content/rhel-ai/cuda-rhel-9-x86_64/Packages/l/libnvidia-ml-580.126.20-1.el9.x86_64.rpm
     repoid: ml-x86_64-baseos-rpms
-    size: 685446
-    checksum: sha256:b261f01cf5bd6cf22c3624e53a6d1df7a20a76bd6a7b2b917c607a153c69dcb1
+    size: 686059
+    checksum: sha256:c9dd2f8dde64372b7ea4ce2ebffdbeb7764668c5aef2f804fe0144343592e1a2
     name: libnvidia-ml
-    evr: 3:580.105.08-1.el9
-    sourcerpm: nvidia-driver-580.105.08-1.el9.src.rpm
+    evr: 3:580.126.20-1.el9
+    sourcerpm: nvidia-driver-580.126.20-1.el9.src.rpm
     module: nvidia-driver:580
   source: []
   module_metadata:


### PR DESCRIPTION
- Update Dockerfile.daemonset.ocp: driver 580.105.08 -> 580.126.20
- Update rpms.lock.yaml to match (will be regenerated by cachi2)
- Fixes NVML driver/library version mismatch in OCP 4.21 e2e tests

GPU Operator 26.3.0 uses NVIDIA driver 580.126.20 as the default. 
The das-daemonset was failing with "nvml init failed: Driver/library version mismatch" when compiled with golang 1.24 for OCP 4.21.
Ref: https://github.com/openshift/release/pull/76675
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/76675/rehearse-76675-pull-ci-openshift-instaslice-operator-next-e2e-bundle-runc/2036401801552465920 