### PR TITLE
NO-JIRA: Increase the timeout to run e2e tests

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -167,7 +167,7 @@ test-e2e e2e-args="-ginkgo.v" focus="":
     fi
 
     echo "=== Running e2e tests ==="
-    GOFLAGS=-mod=vendor go test ./test/e2e -v -count=1 -args ${args[@]}
+    GOFLAGS=-mod=vendor go test ./test/e2e -v -count=1 -timeout=90m -args ${args[@]}
 
 # Deploy all the pre-req operators, das-operator and execute end-to-end tests on CI
 [group('test')]


### PR DESCRIPTION
Sometimes, the tests timeout as observed in [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_instaslice-operator/1041/pull-ci-openshift-instaslice-operator-next-e2e-bundle-runc/2041842402481672192/artifacts/e2e-bundle-runc/openshift-instaslice-operator-e2e-bundle-next-run-e2e/build-log.txt) failure from https://github.com/openshift/instaslice-operator/pull/1041

Although the tests have 60m timeout internally, the `go test` default timeout is `10m` and hence increasing it to `90m`