### PR TITLE
tekton: configure sast-snyk-check to upload results to Snyk UI

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,5 +3,4 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    - vendor/**
     - "**/*_test.go"

--- a/.tekton/instaslice-daemonset-next-pull-request.yaml
+++ b/.tekton/instaslice-daemonset-next-pull-request.yaml
@@ -353,6 +353,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-daemonset --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-daemonset-next-push.yaml
+++ b/.tekton/instaslice-daemonset-next-push.yaml
@@ -333,6 +333,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-daemonset --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-operator-bundle-developer-next-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-developer-next-pull-request.yaml
@@ -335,6 +335,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-operator-bundle-developer --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-operator-bundle-developer-next-push.yaml
+++ b/.tekton/instaslice-operator-bundle-developer-next-push.yaml
@@ -332,6 +332,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-operator-bundle-developer --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-operator-bundle-next-pull-request.yaml
+++ b/.tekton/instaslice-operator-bundle-next-pull-request.yaml
@@ -338,6 +338,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-operator-bundle --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-operator-bundle-next-push.yaml
+++ b/.tekton/instaslice-operator-bundle-next-push.yaml
@@ -335,6 +335,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-operator-bundle --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-operator-next-pull-request.yaml
+++ b/.tekton/instaslice-operator-next-pull-request.yaml
@@ -334,6 +334,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-operator-next-push.yaml
+++ b/.tekton/instaslice-operator-next-push.yaml
@@ -333,6 +333,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-scheduler-next-pull-request.yaml
+++ b/.tekton/instaslice-scheduler-next-pull-request.yaml
@@ -355,6 +355,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-scheduler --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-scheduler-next-push.yaml
+++ b/.tekton/instaslice-scheduler-next-push.yaml
@@ -354,6 +354,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-scheduler --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-webhook-next-pull-request.yaml
+++ b/.tekton/instaslice-webhook-next-pull-request.yaml
@@ -334,6 +334,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-webhook --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/instaslice-webhook-next-push.yaml
+++ b/.tekton/instaslice-webhook-next-push.yaml
@@ -333,6 +333,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=instaslice-webhook --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary

- Add `ARGS` parameter to all `sast-snyk-check` tasks across all 12 Tekton pipeline files (6 components x PR + push) to upload SAST scan results to the Snyk UI
- Each component gets a unique `--project-name` for organized results in the Snyk dashboard
- Remove `vendor/**` from `.snyk` exclusions so SAST scans also cover vendored Go dependencies

## Details

### Snyk ARGS configuration

Per the [Konflux SAST documentation](https://konflux.pages.redhat.com/docs/users/testing/sast-tasks.html), the optional `ARGS` parameter enables uploading scan results to the Snyk UI with `--report` and targeting the correct organization with `--org`.

**Target Snyk org:** Hybrid Platforms - Red Hat OpenShift Container Platform (`86a5b6bf-8aad-4842-ab41-e5c7358c202e`)

| Component | `--project-name` |
|-----------|------------------|
| instaslice-operator | `instaslice-operator` |
| instaslice-daemonset | `instaslice-daemonset` |
| instaslice-scheduler | `instaslice-scheduler` |
| instaslice-webhook | `instaslice-webhook` |
| instaslice-operator-bundle | `instaslice-operator-bundle` |
| instaslice-operator-bundle-developer | `instaslice-operator-bundle-developer` |

### .snyk exclusion update

Removed `vendor/**` from the global exclusion list so Snyk Code also scans vendored dependencies. The `**/*_test.go` exclusion is kept to avoid false positives from test fixtures.

## Test plan

- [ ] Verify `sast-snyk-check` task still passes on PR pipelines
- [ ] Confirm results appear in the [Snyk UI](https://app.snyk.io/) under the correct org and project names
- [ ] Validate vendor code is now included in SAST scan results